### PR TITLE
[Fix] Interface TelegramHttpClientInterface not found

### DIFF
--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -67,7 +67,7 @@ class Telegram
 
         $httpClientHandler = null;
         if (isset($http_client_handler)) {
-            if ($http_client_handler instanceof TelegramHttpClientInterface) {
+            if ($http_client_handler instanceof HttpClientInterface) {
                 $httpClientHandler = $http_client_handler;
             } elseif ($http_client_handler === 'guzzle') {
                 $httpClientHandler = new GuzzleHttpClient();


### PR DESCRIPTION
The bug prevented the construction of Telegram objects with a custom HTTP handler, as the Interface could not be found.