### PR TITLE
[Fix] Telegram\Objects\BaseObject not found in Contact Object class

### DIFF
--- a/src/Objects/Contact.php
+++ b/src/Objects/Contact.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Telegram\Objects;
+namespace Irazasyed\Telegram\Objects;
 
 class Contact extends BaseObject
 {


### PR DESCRIPTION
Fixed namespace to prevent errors like

```
PHP Fatal error:  Class 'Telegram\Objects\BaseObject' not found in /app/vendor/irazasyed/telegram-bot-sdk/src/Objects/Contact.php on line 6
```