### PR TITLE
Added new features from August API Changelog

### DIFF
--- a/src/Objects/Message.php
+++ b/src/Objects/Message.php
@@ -19,6 +19,7 @@ class Message extends BaseObject
             'photo' => PhotoSize::class,
             'sticker' => Sticker::class,
             'video' => Video::class,
+            'voice' => Voice::class,
             'contact' => Contact::class,
             'location' => Location::class,
             'new_chat_participant' => User::class,

--- a/src/Objects/Voice.php
+++ b/src/Objects/Voice.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Irazasyed\Telegram\Objects;
+
+class Voice extends BaseObject
+{
+    /**
+     * @inheritdoc
+     */
+    public function relations()
+    {
+        return [];
+    }
+}

--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -244,17 +244,18 @@ class Telegram
      *
      * @link https://core.telegram.org/bots/api#sendaudio
      *
-     * @param int            $chat_id
-     * @param string         $audio
-     * @param int            $duration
-     * @param int            $reply_to_message_id
+     * @param int $chat_id
+     * @param string $audio
+     * @param int $duration
+     * @param string $performer
+     * @param string $title
+     * @param int $reply_to_message_id
      * @param KeyboardMarkup $reply_markup
-     *
-     * @return \Irazasyed\Telegram\Objects\Message
+     * @return Message
      */
-    public function sendAudio($chat_id, $audio, $duration = null, $reply_to_message_id = null, $reply_markup = null)
+    public function sendAudio($chat_id, $audio, $duration = null, $performer = null, $title = null, $reply_to_message_id = null, $reply_markup = null)
     {
-        $params = compact('chat_id', 'audio', 'duration', 'reply_to_message_id', 'reply_markup');
+        $params = compact('chat_id', 'audio', 'duration', 'performer', 'title', 'reply_to_message_id', 'reply_markup');
 
         return $this->uploadFile('sendAudio', $params);
     }

--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -240,7 +240,7 @@ class Telegram
     }
 
     /**
-     * Send audio files.
+     * Send regular audio files.
      *
      * @link https://core.telegram.org/bots/api#sendaudio
      *
@@ -257,6 +257,26 @@ class Telegram
         $params = compact('chat_id', 'audio', 'duration', 'reply_to_message_id', 'reply_markup');
 
         return $this->uploadFile('sendAudio', $params);
+    }
+
+    /**
+     * Send voice audio files.
+     *
+     * @link https://core.telegram.org/bots/api#sendaudio
+     *
+     * @param int            $chat_id
+     * @param string         $voice
+     * @param int            $duration
+     * @param int            $reply_to_message_id
+     * @param KeyboardMarkup $reply_markup
+     *
+     * @return \Irazasyed\Telegram\Objects\Message
+     */
+    public function sendVoice($chat_id, $voice, $duration = null, $reply_to_message_id = null, $reply_markup = null)
+    {
+        $params = compact('chat_id', 'voice', 'duration', 'reply_to_message_id', 'reply_markup');
+
+        return $this->uploadFile('sendVoice', $params);
     }
 
     /**


### PR DESCRIPTION
As from the latest [Official API changelog](https://core.telegram.org/bots/api-changelog#august-15-2015)

>August 15, 2015
>Added new type Voice and new method sendVoice for sending voice messages.
>Earlier Audio and sendAudio should now be used for sending music files. Telegram clients will show such files in the in-app music player. If you were using sendAudio for your bot to send voice messages, please use sendVoice instead.
>Added optional fields performer, title to the Audio object and sendAudio method.
>Added optional field voice to the Message object.


This PR adds all new features in the above changelog to the the bot sdk.