### PR TITLE
Add list of bots allowed to use a command

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -58,6 +58,11 @@ class Api
     protected $commandBus = null;
 
     /**
+     * @var string|null Telegram bot's username.
+     */
+    protected $name = null;
+
+    /**
      * Instantiates a new Telegram super-class object.
      *
      *
@@ -228,6 +233,21 @@ class Api
         $response = $this->post('getMe');
 
         return new User($response->getDecodedBody());
+    }
+
+    /**
+     * A simple method for getting your bot's name.
+     * Returns string information about the bot's name.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        if (!isset($this->name))
+        {
+            $this->name = $this->getMe()['username'];
+        }
+        return $this->name;
     }
 
     /**

--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -51,6 +51,11 @@ abstract class Command implements CommandInterface
     protected $update;
 
     /**
+     * @var array|null List of bots' name which this command is available for.
+     */
+    protected $bots;
+
+    /**
      * Get Command Name.
      *
      * @return string
@@ -136,6 +141,16 @@ abstract class Command implements CommandInterface
     public function getCommandBus()
     {
         return $this->telegram->getCommandBus();
+    }
+
+    /**
+     * Checks if this command is available for this bot.
+     *
+     * @return Boolean
+     */
+    public function availableFor(Api $telegram)
+    {
+        return isset($this->bots) ? in_array($telegram->getName(), $this->bots) : true;
     }
 
     /**

--- a/src/Commands/CommandBus.php
+++ b/src/Commands/CommandBus.php
@@ -161,7 +161,9 @@ class CommandBus
      */
     public function execute($name, $arguments, $message)
     {
-        if (array_key_exists($name, $this->commands)) {
+        if (array_key_exists($name, $this->commands)
+            && $this->commands[$name]->availableFor($this->telegram)
+        ) {
             return $this->commands[$name]->make($this->telegram, $arguments, $message);
         } elseif (array_key_exists('help', $this->commands)) {
             return $this->commands['help']->make($this->telegram, $arguments, $message);


### PR DESCRIPTION
Add an extra array in Command class to specify the bot usernames which can execute this command.
If this array is not set, this command is available to run. Fix #33 