### PR TITLE
Improve mapRelatives in BaseObject

### DIFF
--- a/src/Objects/BaseObject.php
+++ b/src/Objects/BaseObject.php
@@ -65,6 +65,11 @@ abstract class BaseObject extends Collection
             foreach ($relations as $property => $class) {
                 if (!is_object($data) && isset($results[$key][$property])) {
                     $results[$key][$property] = new $class($results[$key][$property]);
+                    continue;
+                }
+                
+                if ($key === $property) {
+                    $results[$key] = new $class($results[$key]);
                 }
             }
         }


### PR DESCRIPTION
@irazasyed mapRelatives doesn't really supports initializing inner properties
So for example we get webhook update. Message is transformed to object of Message class, but 'from' and 'chat' fields are not.
This code fixes it. I am not sure if you need that continue, but second if does all the job.