### PR TITLE
Changelog broken link fixed

### DIFF
--- a/upgrade/index.html
+++ b/upgrade/index.html
@@ -203,7 +203,7 @@
                 <div class="col-md-9" role="main">
 
 <h1 id="upgrade-guide">Upgrade Guide</h1>
-<p>Please make sure you are viewing this file on the master branch. Check out the <a href="https://github.com/irazasyed/telegram-bot-sdk/blob/master/CHANGELOG.md">CHANGELOG</a> for detailed info on whats changed.</p>
+<p>Please make sure you are viewing this file on the master branch. Check out the <a href="../changelog/">CHANGELOG</a> for detailed info on whats changed.</p>
 <h2 id="upgrading-to-10-from-0x">Upgrading To 1.0 from 0.x</h2>
 <p>There are some breaking and major changes in this new version. Follow the below instructions to apply the changes.</p>
 <h4 id="upgrading-your-composer-dependency">Upgrading Your Composer Dependency</h4>

--- a/upgrade/index.html
+++ b/upgrade/index.html
@@ -218,7 +218,7 @@
 </code></pre>
 
 <h4 id="updating-sendaudio-method">Updating <code>sendAudio</code> Method</h4>
-<p>If you're using <code>sendAudio()</code> method anywhere in your project, Make sure you update that as per the new parameters and API change. Refer the <a href="https://github.com/irazasyed/telegram-bot-sdk/blob/master/CHANGELOG.md">CHANGELOG</a> and API <a href="https://github.com/irazasyed/telegram-bot-sdk/blob/master/src/Api.php#L297-L324">file</a>.</p>
+<p>If you're using <code>sendAudio()</code> method anywhere in your project, Make sure you update that as per the new parameters and API change. Refer the <a href="../changelog/">CHANGELOG</a> and API <a href="https://github.com/irazasyed/telegram-bot-sdk/blob/master/src/Api.php#L297-L324">file</a>.</p>
 <h3 id="upgrading-to-10-in-laravel-lumen">Upgrading To 1.0 in Laravel / Lumen</h3>
 <p>Addition to the above instructions, You also need to apply the below instructions to get the package working in your Laravel or Lumen Project.</p>
 <h4 id="update-service-provider">Update Service Provider</h4>


### PR DESCRIPTION
Old url is broken, that's why I could use new one:
https://github.com/irazasyed/telegram-bot-sdk/blob/master/docs/changelog.md

But I changed it to the current site page.