### PR TITLE
Make arguments passed to call_user_func_array() a little easier to un…

### DIFF
--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -188,9 +188,9 @@ abstract class Command implements CommandInterface
             }
 
             $chat_id = $this->update->getMessage()->getChat()->getId();
-            $params[] = array_merge(compact('chat_id'), $arguments[0]);
+            $params = array_merge(compact('chat_id'), $arguments[0]);
 
-            return call_user_func_array([$this->telegram, $methodName], $params);
+            return call_user_func_array([$this->telegram, $methodName], [$params]);
         }
 
         return 'Method Not Found';


### PR DESCRIPTION
…derstand.

From the php docs:
![image](https://cloud.githubusercontent.com/assets/2513663/11422924/e5d829c4-9437-11e5-8b52-d9d8bcbbe037.png)

__Purely a visual thing__. I think formatting the array in this way in this PR, makes it clear that we have passed an array to the `call_user_func_array()` method.

It also makes it easier to add MORE arguments in the future if any ever need to be sent. We can just do:
`return call_user_func_array([$this->telegram, $methodName], [$params, $secondArg]);`