### PR TITLE
Add a custom ruleset file for phpcs.

### DIFF
--- a/ruleset.xml
+++ b/ruleset.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<ruleset name="Selective Standard">
+    <rule ref="PSR2">
+        <exclude name="PSR1.Methods.CamelCapsMethodName.NotCamelCaps"/>
+    </rule>
+
+    <rule ref="Generic.Files.LineLength">
+        <properties>
+            <property phpcs-only="true" name="lineLimit" value="150"/>
+        </properties>
+    </rule>
+
+</ruleset>


### PR DESCRIPTION
Adding this ruleset for [phpcs](http://cs.sensiolabs.org/) (do not confuse with [php-cs-fxer](https://github.com/FriendsOfPHP/PHP-CS-Fixer)) allows us to ignore some rules which don't suit for this project.

Mainly the line length requirement of 80/120 is broken in various places because of our requirement to add the @methods to the top of some classes. If we were to break the lines up it would look terrible.

If you are using phpstorm, it's very easy to have live notification of phpcs errors. 

* Firstly download/install phpcs any way that suits. In my case I just used the `phpcs.phar` file.
* Add the path to the phar file in phpstorm settings
![image](https://cloud.githubusercontent.com/assets/2513663/11626833/d4716a5c-9cdd-11e5-9082-651a091686ee.png)
* Enable the phpcs inspections, to make it acknowledge the custom ruleset, just follow the numbers in this picture:
![image](https://cloud.githubusercontent.com/assets/2513663/11626848/f62f3246-9cdd-11e5-98d8-e0ceaff01337.png)

Your done!


