### PR TITLE
Updated some new docs. Added tests for CommandBus

### DIFF
--- a/src/Objects/Chat.php
+++ b/src/Objects/Chat.php
@@ -7,7 +7,7 @@ namespace Telegram\Bot\Objects;
  *
  *
  * @method int      getId()        Unique identifier for this chat, not exceeding 1e13 by absolute value.
- * @method string   getType()      Type of chat, can be either “private” or “group” or “channel”.
+ * @method string   getType()      Type of chat, can be either 'private', 'group', 'supergroup' or 'channel'.
  * @method string   getTitle()     (Optional). Title, for channels and group chats.
  * @method string   getUsername()  (Optional). Username, for private chats and channels if available
  * @method string   getFirstName() (Optional). First name of the other party in a private chat

--- a/src/Objects/Message.php
+++ b/src/Objects/Message.php
@@ -23,16 +23,16 @@ namespace Telegram\Bot\Objects;
  * @method string           getCaption()                (Optional). Caption for the photo or video contact.
  * @method Contact          getContact()                (Optional). Message is a shared contact, information about the contact.
  * @method Location         getLocation()               (Optional). Message is a shared location, information about the location.
- * @method User             getNewChatParticipant()     (Optional). A new member was added to the group, information about them (this member may be bot itself).
- * @method User             getLeftChatParticipant()    (Optional). A member was removed from the group, information about them (this member may be bot itself).
+ * @method User             getNewChatParticipant()     (Optional). A new member was added to the group, information about them (this member may be the bot itself).
+ * @method User             getLeftChatParticipant()    (Optional). A member was removed from the group, information about them (this member may be the bot itself).
  * @method string           getNewChatTitle()           (Optional). A chat title was changed to this value.
  * @method PhotoSize[]      getNewChatPhoto()           (Optional). A chat photo was change to this value.
- * @method bool             getDeleteChatPhoto()        (Optional). Informs that the chat photo was deleted.
- * @method bool             getGroupChatCreated()       (Optional). Informs that the group has been created.
- * @method bool             getSupergroupChatCreated()  (Optional). Informs that the super group has been created.
- * @method bool             getChannelChatCreated()     (Optional). Informs that the channel has been created.
- * @method int              getMigrateToChatId()        (Optional). The chat has been migrated to a chat with specified identifier, not exceeding 1e13 by absolute value.
- * @method int              getMigrateFromChatId()      (Optional). The chat has been migrated from a chat with specified identifier, not exceeding 1e13 by absolute value.
+ * @method bool             getDeleteChatPhoto()        (Optional). Service message: the chat photo was deleted.
+ * @method bool             getGroupChatCreated()       (Optional). Service message: the group has been created.
+ * @method bool             getSupergroupChatCreated()  (Optional). Service message: the super group has been created.
+ * @method bool             getChannelChatCreated()     (Optional). Service message: the channel has been created.
+ * @method int              getMigrateToChatId()        (Optional). The group has been migrated to a supergroup with the specified identifier, not exceeding 1e13 by absolute value.
+ * @method int              getMigrateFromChatId()      (Optional). The supergroup has been migrated from a group with the specified identifier, not exceeding 1e13 by absolute value.
  */
 class Message extends BaseObject
 {

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -13,8 +13,6 @@ use Telegram\Bot\Objects\Message;
 use Telegram\Bot\TelegramResponse;
 use Telegram\Bot\Tests\Mocks\Mocker;
 use Telegram\Bot\Commands\CommandBus;
-use Telegram\Bot\Tests\Mocks\MockCommand;
-use Telegram\Bot\Tests\Mocks\MockCommandTwo;
 use Telegram\Bot\HttpClients\GuzzleHttpClient;
 
 class ApiTest extends \PHPUnit_Framework_TestCase
@@ -30,9 +28,10 @@ class ApiTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @test
      * @expectedException \Telegram\Bot\Exceptions\TelegramSDKException
      */
-    public function testThrowsExceptionOnNullToken()
+    public function it_throws_exception_when_no_token_is_provided()
     {
         new Api();
     }
@@ -50,7 +49,8 @@ class ApiTest extends \PHPUnit_Framework_TestCase
         $this->api->setAccessToken($type);
     }
 
-    public function testReturnsPassedToken()
+    /** @test */
+    public function it_checks_the_passed_api_token_is_returned()
     {
         $this->assertEquals('token', $this->api->getAccessToken());
         $this->api->setAccessToken('another');
@@ -70,44 +70,33 @@ class ApiTest extends \PHPUnit_Framework_TestCase
     /** @test
      * @expectedException InvalidArgumentException
      */
-    public function it_throws_exception_if_httpclient_is_not_specified_correctly()
+    public function it_throws_exception_if_httpClient_is_not_specified_correctly()
     {
         $this->api = new Api('token', false, 'test');
     }
 
-    public function testReturnsClientObject()
+    /** @test */
+    public function it_checks_the_Client_object_is_returned()
     {
         $this->assertInstanceOf(TelegramClient::class, $this->api->getClient());
     }
 
-    public function testReturnsCommandBus()
+    /** @test */
+    public function it_checks_the_commandBus_is_returned()
     {
         $this->assertInstanceOf(CommandBus::class, $this->api->getCommandBus());
     }
 
-    public function testAddsAndReturnsInstantiatedCommands()
-    {
-        $this->api->addCommand(MockCommand::class);
-        $commands = $this->api->getCommands();
-        $this->assertInstanceOf(MockCommand::class, $commands['mycommand']);
-    }
-
-    public function testAddsMultipleCommands()
-    {
-        $this->api->addCommands([MockCommand::class, MockCommandTwo::class]);
-        $commands = $this->api->getCommands();
-        $this->assertInstanceOf(MockCommand::class, $commands['mycommand']);
-        $this->assertInstanceOf(MockCommandTwo::class, $commands['mycommand2']);
-    }
-
-    public function testCommandsHandlerReturnsUpdates()
+    /** @test */
+    public function it_checks_an_update_object_is_returned_when_a_command_is_handled()
     {
         $this->api = Mocker::createMessageResponse('/start');
         $updates = $this->api->commandsHandler();
         $this->assertInstanceOf(Update::class, $updates[0]);
     }
 
-    public function testHandlesTheRightCommand()
+    /** @test */
+    public function it_checks_the_correct_command_is_handled()
     {
         $this->api = Mocker::createMessageResponse('/mycommand');
         $command = Mocker::createMockCommand('mycommand');
@@ -119,61 +108,6 @@ class ApiTest extends \PHPUnit_Framework_TestCase
 
         $command->make(Argument::any(), Argument::any(), Argument::any())->shouldHaveBeenCalled();
         $command2->make(Argument::any(), Argument::any(), Argument::any())->shouldNotHaveBeenCalled();
-    }
-
-    /**
-     * @test
-     * @expectedException \Telegram\Bot\Exceptions\TelegramSDKException
-     */
-    public function it_throws_exception_if_supplied_command_class_does_not_exist()
-    {
-        $this->api->addCommand('nonexistclass');
-    }
-
-    /**
-     * @test
-     * @expectedException \Telegram\Bot\Exceptions\TelegramSDKException
-     */
-    public function it_checks_a_supplied_command_object_is_of_the_correct_type()
-    {
-        $this->api->addCommand(new \stdClass());
-    }
-
-    /** @test */
-    public function it_removes_a_command()
-    {
-        $this->api->addCommands([MockCommand::class, MockCommandTwo::class]);
-        $this->api->removeCommand('mycommand');
-
-        $commands = $this->api->getCommands();
-
-        $this->assertCount(1, $commands);
-        $this->assertArrayNotHasKey('mycommand', $commands);
-        $this->assertInstanceOf(MockCommandTwo::class, $commands['mycommand2']);
-    }
-
-    /** @test */
-    public function it_removes_multiple_commands()
-    {
-        $this->api->addCommands([MockCommand::class, MockCommandTwo::class]);
-        $this->api->removeCommands(['mycommand', 'mycommand2']);
-
-        $commands = $this->api->getCommands();
-
-        $this->assertCount(0, $commands);
-        $this->assertArrayNotHasKey('mycommand', $commands);
-        $this->assertArrayNotHasKey('mycommand2', $commands);
-    }
-
-    /**
-     * @test
-     * @expectedException \InvalidArgumentException
-     */
-    public function it_throws_exception_if_inbound_message_has_blank_text()
-    {
-        $this->api = Mocker::createMessageResponse('');
-
-        $this->api->commandsHandler();
     }
 
     /** @test */

--- a/tests/CommandBusTest.php
+++ b/tests/CommandBusTest.php
@@ -21,14 +21,17 @@ class CommandBusTest extends \PHPUnit_Framework_TestCase
         $this->commandBus = new CommandBus(Mocker::createApi()->reveal());
     }
 
-    public function testAddsAndReturnsInstantiatedCommands()
+    /** @test */
+    public function it_adds_a_command_and_checks_commands_can_be_returned()
     {
         $this->commandBus->addCommand(MockCommand::class);
         $commands = $this->commandBus->getCommands();
         $this->assertInstanceOf(MockCommand::class, $commands['mycommand']);
+        $this->assertCount(1, $commands);
     }
 
-    public function testAddsMultipleCommands()
+    /** @test */
+    public function it_adds_multiple_commands()
     {
         $this->commandBus->addCommands([MockCommand::class, MockCommandTwo::class]);
         $commands = $this->commandBus->getCommands();
@@ -86,7 +89,7 @@ class CommandBusTest extends \PHPUnit_Framework_TestCase
      * @test
      * @expectedException \InvalidArgumentException
      */
-    public function it_throws_exception_if_message_is_blank_text()
+    public function it_throws_exception_if_message_is_only_blank_text()
     {
         $this->commandBus->parseCommand('');
     }

--- a/tests/CommandBusTest.php
+++ b/tests/CommandBusTest.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Telegram\Bot\Tests;
+
+use Prophecy\Argument;
+use Telegram\Bot\Objects\Update;
+use Telegram\Bot\Tests\Mocks\Mocker;
+use Telegram\Bot\Commands\CommandBus;
+use Telegram\Bot\Tests\Mocks\MockCommand;
+use Telegram\Bot\Tests\Mocks\MockCommandTwo;
+
+class CommandBusTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var CommandBus
+     */
+    protected $commandBus;
+
+    public function setUp()
+    {
+        $this->commandBus = new CommandBus(Mocker::createApi()->reveal());
+    }
+
+    public function testAddsAndReturnsInstantiatedCommands()
+    {
+        $this->commandBus->addCommand(MockCommand::class);
+        $commands = $this->commandBus->getCommands();
+        $this->assertInstanceOf(MockCommand::class, $commands['mycommand']);
+    }
+
+    public function testAddsMultipleCommands()
+    {
+        $this->commandBus->addCommands([MockCommand::class, MockCommandTwo::class]);
+        $commands = $this->commandBus->getCommands();
+
+        $this->assertInstanceOf(MockCommand::class, $commands['mycommand']);
+        $this->assertInstanceOf(MockCommandTwo::class, $commands['mycommand2']);
+    }
+
+    /** @test */
+    public function it_removes_a_command()
+    {
+        $this->commandBus->addCommands([MockCommand::class, MockCommandTwo::class]);
+        $this->commandBus->removeCommand('mycommand');
+
+        $commands = $this->commandBus->getCommands();
+
+        $this->assertCount(1, $commands);
+        $this->assertArrayNotHasKey('mycommand', $commands);
+        $this->assertInstanceOf(MockCommandTwo::class, $commands['mycommand2']);
+    }
+
+    /** @test */
+    public function it_removes_multiple_commands()
+    {
+        $this->commandBus->addCommands([MockCommand::class, MockCommandTwo::class]);
+        $this->commandBus->removeCommands(['mycommand', 'mycommand2']);
+
+        $commands = $this->commandBus->getCommands();
+
+        $this->assertCount(0, $commands);
+        $this->assertArrayNotHasKey('mycommand', $commands);
+        $this->assertArrayNotHasKey('mycommand2', $commands);
+    }
+
+    /**
+     * @test
+     * @expectedException \Telegram\Bot\Exceptions\TelegramSDKException
+     */
+    public function it_checks_a_supplied_command_object_is_of_the_correct_type()
+    {
+        $this->commandBus->addCommand(new \stdClass());
+    }
+
+    /**
+     * @test
+     * @expectedException \Telegram\Bot\Exceptions\TelegramSDKException
+     */
+    public function it_throws_exception_if_supplied_command_class_does_not_exist()
+    {
+        $this->commandBus->addCommand('nonexistclass');
+    }
+
+
+    /**
+     * @test
+     * @expectedException \InvalidArgumentException
+     */
+    public function it_throws_exception_if_message_is_blank_text()
+    {
+        $this->commandBus->parseCommand('');
+    }
+
+    /** @test */
+    public function it_parses_the_commandText_correctly()
+    {
+        $result = $this->commandBus->parseCommand('/userCommand@botname arg1 arg2');
+
+        $this->assertEquals('userCommand', $result[1]);
+        $this->assertEquals('botname', $result[2]);
+        $this->assertEquals('arg1 arg2', $result[3]);
+    }
+
+    /** @test */
+    public function it_parses_the_commandText_correctly_2()
+    {
+        $result = $this->commandBus->parseCommand('/userCommand arg1 arg2');
+
+        $this->assertEquals('userCommand', $result[1]);
+        $this->assertEmpty($result[2]);
+        $this->assertEquals('arg1 arg2', $result[3]);
+    }
+
+    /** @test */
+    public function it_parses_the_commandText_correctly_3()
+    {
+        $result = $this->commandBus->parseCommand('sometext first /userCommand arg1 arg2');
+
+        $this->assertEmpty($result);
+    }
+
+    /** @test */
+    public function it_returns_the_result_from_the_handle_method_on_the_command()
+    {
+        $command = new MockCommand();
+        $this->commandBus->addCommand($command);
+
+        $res = $this->commandBus->execute('mycommand', '', Mocker::createUpdateResponse());
+
+        $this->assertEquals('mycommand handled', $res);
+    }
+
+    /** @test */
+    public function it_handles_a_command_and_returns_the_update_object_correctly()
+    {
+        $command = Mocker::createMockCommand('mycommand');
+        $this->commandBus->addCommand($command->reveal());
+
+        $result = $this->commandBus->handler('/mycommand', Mocker::createUpdateObject()->reveal());
+
+        $this->assertInstanceOf(Update::class, $result);
+    }
+}

--- a/tests/Mocks/MockCommand.php
+++ b/tests/Mocks/MockCommand.php
@@ -6,11 +6,18 @@ use Telegram\Bot\Commands\Command;
 
 class MockCommand extends Command
 {
+
+    public function __construct()
+    {
+    }
+
+
     protected $name = 'mycommand';
 
     protected $description = 'a mock command';
 
     public function handle($args)
     {
+        return 'mycommand handled';
     }
 }

--- a/tests/Mocks/Mocker.php
+++ b/tests/Mocks/Mocker.php
@@ -8,11 +8,35 @@ use Prophecy\Argument;
 use GuzzleHttp\Client;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
+use Telegram\Bot\Objects\Update;
 use GuzzleHttp\Handler\MockHandler;
 use Telegram\Bot\HttpClients\GuzzleHttpClient;
 
 class Mocker
 {
+    /**
+     * Create a mocked API object with a container.
+     *
+     * @return \Prophecy\Prophecy\ObjectProphecy
+     */
+    public static function createApi()
+    {
+        $api = (new Prophet())->prophesize(Api::class);
+        $api->hasContainer()->willReturn(true);
+
+        return $api;
+    }
+
+    /**
+     * Create a mocked Update Object
+     *
+     * @return \Prophecy\Prophecy\ObjectProphecy
+     */
+    public static function createUpdateObject()
+    {
+        return (new Prophet())->prophesize(Update::class);
+    }
+
     /**
      * Creates a stub command that responds to getName() and make() method calls.
      *
@@ -38,7 +62,7 @@ class Mocker
      *
      * @return Api
      */
-    public static function createUpdateResponse(array $updateFields, $updateId = '1')
+    public static function createUpdateResponse(array $updateFields = [], $updateId = '1')
     {
         $defaultResponseFields = [
             'message_id' => '',


### PR DESCRIPTION
Some new text was added to the official docs. Reflected in the code now.

Also, I'm confused again about these tests.

I wanted to create a new test class to test the public methods on the `CommandBus.php` file. As I started to write the tests I realised that some of them have already been done from the `ApiTests.php` file.

This is because a lot of the tests in the `ApiTests.php` file, accessed the commandbus object before doing some work. ie `$this->api->addCommands()` is really a helper function/alias for `$this->getCommandBus()->addCommands()`

So where should the tests live? In the api test file or the commandbus test file? I have no idea.

So at the moment about 30% of the `commandBusTests` file has duplicate tests from the api tests.

I'm sure someone will be able to enlighten me on what the best way to organise these are.

As it stands all tests are green. :)