### PR TITLE
Prevent Fatal error: Call to a member function has() on null

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -867,7 +867,7 @@ class Api
     {
         $message = $update->getMessage();
 
-        if ($message->has('text')) {
+        if ($message !== null && $message->has('text')) {
             $this->getCommandBus()->handler($message->getText(), $update);
         }
     }


### PR DESCRIPTION
Fatal error: Call to a member function has() on null in .../vendor/irazasyed/telegram-bot-sdk/src/Api.php on line 870

Appears when is no message received. 
To trigger: just open webhook in browser