### PR TITLE
Fix Dependency Injection in command's constructors. With tests.

### DIFF
--- a/src/Laravel/TelegramServiceProvider.php
+++ b/src/Laravel/TelegramServiceProvider.php
@@ -63,13 +63,13 @@ class TelegramServiceProvider extends ServiceProvider
                 $config->get('telegram.http_client_handler', null)
             );
 
-            // Register Commands
-            $telegram->addCommands($config->get('telegram.commands', []));
-
             // Check if DI needs to be enabled for Commands
-            if ($config->get('telegram.inject_command_dependencies', false)) {
+            if ($config->get('telegram.resolve_command_dependencies', false)) {
                 $telegram->setContainer($app);
             }
+
+            // Register Commands
+            $telegram->addCommands($config->get('telegram.commands', []));
 
             return $telegram;
         });

--- a/src/Laravel/config/telegram.php
+++ b/src/Laravel/config/telegram.php
@@ -43,6 +43,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Resolve Injected Dependencies in commands [Optional]
+    |--------------------------------------------------------------------------
+    |
+    | Using Laravel's IoC container, we can easily type hint dependencies in
+    | our command's constructor and have them automatically resolved for us.
+    |
+    | Default: true
+    | Possible Values: (Boolean) "true" OR "false"
+    |
+    */
+    'resolve_command_dependencies' => true,
+
+    /*
+    |--------------------------------------------------------------------------
     | Register Telegram Commands [Optional]
     |--------------------------------------------------------------------------
     |

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -88,6 +88,14 @@ class ApiTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
+    public function it_checks_an_ioc_container_can_be_set()
+    {
+        $this->api->setContainer(Mocker::createContainer()->reveal());
+
+        $this->assertInstanceOf('\Illuminate\Contracts\Container\Container', $this->api->getContainer());
+    }
+    
+    /** @test */
     public function it_checks_an_update_object_is_returned_when_a_command_is_handled()
     {
         $this->api = Mocker::createMessageResponse('/start');

--- a/tests/CommandBusTest.php
+++ b/tests/CommandBusTest.php
@@ -4,6 +4,7 @@ namespace Telegram\Bot\Tests;
 
 use Prophecy\Argument;
 use Telegram\Bot\Objects\Update;
+use Telegram\Bot\Commands\Command;
 use Telegram\Bot\Tests\Mocks\Mocker;
 use Telegram\Bot\Commands\CommandBus;
 use Telegram\Bot\Tests\Mocks\MockCommand;
@@ -143,4 +144,18 @@ class CommandBusTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf(Update::class, $result);
     }
+
+    /** @test */
+    public function it_checks_a_commands_dependencies_will_be_resolved_if_an_ioc_container_has_been_set()
+    {
+        //Make an API with an IOC container
+        $this->commandBus = new CommandBus(Mocker::createApi(true)->reveal());
+        $this->commandBus->addCommand('\Telegram\Bot\Tests\Mocks\MockCommandWithDependency');
+        $allCommands = $this->commandBus->getCommands();
+
+        $this->assertCount(1, $allCommands);
+        $this->assertArrayHasKey('mycommandwithdependency', $allCommands);
+        $this->assertInstanceOf(Command::class, $allCommands['mycommandwithdependency']);
+    }
+
 }

--- a/tests/Mocks/MockCommandWithDependency.php
+++ b/tests/Mocks/MockCommandWithDependency.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Telegram\Bot\Tests\Mocks;
+
+use Telegram\Bot\Commands\Command;
+
+class MockCommandWithDependency extends Command
+{
+
+    /**
+     * @var \stdClass
+     */
+    protected $stdClass;
+
+    public function __construct(\stdClass $stdClass)
+    {
+        $this->stdClass = $stdClass;
+    }
+
+
+    protected $name = 'mycommandwithdependency';
+
+    protected $description = 'a mock command that has a dependency';
+
+    public function handle($args)
+    {
+        return 'mycommandwithdependency handled';
+    }
+}

--- a/tests/Mocks/Mocker.php
+++ b/tests/Mocks/Mocker.php
@@ -17,14 +17,35 @@ class Mocker
     /**
      * Create a mocked API object with a container.
      *
+     * @param bool $withContainer Should the mocked object have a mocked
+     *                            container added to it?
+     *
      * @return \Prophecy\Prophecy\ObjectProphecy
      */
-    public static function createApi()
+    public static function createApi($withContainer = false)
     {
+        if ($withContainer) {
+            $container = Mocker::createContainer();
+            $container->make(Argument::any())->willReturn(new \stdClass());
+        } else {
+            $container = null;
+        }
+
         $api = (new Prophet())->prophesize(Api::class);
-        $api->hasContainer()->willReturn(true);
+        $api->hasContainer()->willReturn($withContainer);
+        $api->getContainer()->willReturn($container);
 
         return $api;
+    }
+
+    /**
+     * Create an IOC container that can be added to the API
+     *
+     * @return \Prophecy\Prophecy\ObjectProphecy
+     */
+    public static function createContainer()
+    {
+        return (new Prophet())->prophesize(\Illuminate\Contracts\Container\Container::class);
     }
 
     /**


### PR DESCRIPTION
This PR [https://github.com/irazasyed/telegram-bot-sdk/pull/53] had a number of issues that I only discovered tonight.

1) The laravel service provider was looking for a config value called: `inject_command_dependencies` yet that value/key is not found in the `telegram.php` config file.

2) The name didn't make sense. We aren't asking the user do they want to inject a dependency, we can't inject anything for them....we are asking do they want their dependency automatically RESOLVED...that we CAN do.

Therefore I added the new key and changed the name to `resolve_command_dependencies`.

3) The service provider was originally registering the commands THEN checking to see should it resolve any dependencies for any commands to be added. It was too late at that stage! 

Changed the order around in the service provider so that it knows to resolve dependencies before any commands are registered.

4) New option added in the config file.

5) Tests added to check that the dependencies are being resolved if an IOC container has been set.