### PR TITLE
Ensure inbound commands are converted to lowercase before being proce…

### DIFF
--- a/src/Commands/CommandBus.php
+++ b/src/Commands/CommandBus.php
@@ -151,7 +151,7 @@ class CommandBus
     {
         $match = $this->parseCommand($message);
         if (!empty($match)) {
-            $command = $match[1];
+            $command = strtolower($match[1]); //All commands must be lowercase.
 //            $bot = (!empty($match[2])) ? $match[2] : '';
             $arguments = $match[3];
             $this->execute($command, $arguments, $update);


### PR DESCRIPTION
…ssed.

When commands are set with the BotFather, they MUST be in lowercase otherwise they are rejected. Some people when using phones and typing commands find that the phone autocorrects the command and inserts capital letters eg:

/image => /Image

By converting all inbound commands to lowercase we can ensure that the bot replies to a command even if there is a "typo" in it.