### PR TITLE
Implement some of new Telegram Bot v2 API updates

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -1006,6 +1006,7 @@ class Api
         }
 
         $types = [
+            'text',
             'audio',
             'document',
             'photo',
@@ -1015,10 +1016,17 @@ class Api
             'contact',
             'location',
             'venue',
-            'text',
             'new_chat_member',
             'left_chat_member',
+            'new_chat_title',
+            'new_chat_photo',
+            'delete_chat_photo',
+            'group_chat_created',
+            'supergroup_chat_created',
+            'channel_chat_created',
             'migrate_to_chat_id',
+            'migrate_from_chat_id',
+            'pinned_message',
         ];
 
         return $object->keys()

--- a/src/Api.php
+++ b/src/Api.php
@@ -519,6 +519,82 @@ class Api
     }
 
     /**
+     * Send information about a venue.
+     *
+     * <code>
+     * $params = [
+     *   'chat_id'              => '',
+     *   'latitude'             => '',
+     *   'longitude'            => '',
+     *   'title'                => '',
+     *   'address'              => '',
+     *   'foursquare_id'        => '',
+     *   'disable_notification' => '',
+     *   'reply_to_message_id'  => '',
+     *   'reply_markup'         => '',
+     * ];
+     * </code>
+     *
+     * @link https://core.telegram.org/bots/api#sendvenue
+     *
+     * @param array    $params
+     *
+     * @var int|string $params ['chat_id']
+     * @var float      $params ['latitude']
+     * @var float      $params ['longitude']
+     * @var string     $params ['title']
+     * @var string     $params ['address']
+     * @var string     $params ['foursquare_id']
+     * @var bool       $params ['disable_notification']
+     * @var int        $params ['reply_to_message_id']
+     * @var string     $params ['reply_markup']
+     *
+     * @return Message
+     */
+    public function sendVenue(array $params)
+    {
+        $response = $this->post('sendVenue', $params);
+
+        return new Message($response->getDecodedBody());
+    }
+
+    /**
+     * Send phone contacts.
+     *
+     * <code>
+     * $params = [
+     *   'chat_id'              => '',
+     *   'phone_number'         => '',
+     *   'first_name'           => '',
+     *   'last_name'            => '',
+     *   'disable_notification' => '',
+     *   'reply_to_message_id'  => '',
+     *   'reply_markup'         => '',
+     * ];
+     * </code>
+     *
+     * @link https://core.telegram.org/bots/api#sendcontact
+     *
+     * @param array    $params
+     *
+     * @var int|string $params ['chat_id']
+     * @var string     $params ['phone_number']
+     * @var string     $params ['first_name']
+     * @var string     $params ['last_name']
+     * @var bool       $params ['disable_notification']
+     * @var int        $params ['reply_to_message_id']
+     * @var string     $params ['reply_markup']
+     *
+     * @return Message
+     */
+    public function sendContact(array $params)
+    {
+        $response = $this->post('sendContact', $params);
+
+        return new Message($response->getDecodedBody());
+    }
+
+    /**
      * Broadcast a Chat Action.
      *
      * <code>
@@ -613,6 +689,63 @@ class Api
         $response = $this->post('getFile', $params);
 
         return new File($response->getDecodedBody());
+    }
+
+    /**
+     * Kick a user from a group or a supergroup.
+     *
+     * In the case of supergroups, the user will not be able to return to the group on their own using
+     * invite links etc., unless unbanned first.
+     *
+     * The bot must be an administrator in the group for this to work.
+     *
+     * <code>
+     * $params = [
+     *   'chat_id'              => '',
+     *   'user_id'              => '',
+     * ];
+     * </code>
+     *
+     * @link https://core.telegram.org/bots/api#kickchatmember
+     *
+     * @param array    $params
+     *
+     * @var int|string $params ['chat_id']
+     * @var int        $params ['user_id']
+     *
+     * @return TelegramResponse
+     */
+    public function kickChatMember(array $params)
+    {
+        return $this->post('kickChatMember', $params);
+    }
+
+    /**
+     * Unban a previously kicked user in a supergroup.
+     *
+     * The user will not return to the group automatically, but will be able to join via link, etc.
+     *
+     * The bot must be an administrator in the group for this to work.
+     *
+     * <code>
+     * $params = [
+     *   'chat_id'              => '',
+     *   'user_id'              => '',
+     * ];
+     * </code>
+     *
+     * @link https://core.telegram.org/bots/api#unbanchatmember
+     *
+     * @param array    $params
+     *
+     * @var int|string $params ['chat_id']
+     * @var int        $params ['user_id']
+     *
+     * @return TelegramResponse
+     */
+    public function unbanChatMember(array $params)
+    {
+        return $this->post('unbanChatMember', $params);
     }
 
     /**
@@ -872,7 +1005,21 @@ class Api
             $object = $object->getMessage();
         }
 
-        $types = ['audio', 'document', 'photo', 'sticker', 'video', 'voice', 'contact', 'location', 'text'];
+        $types = [
+            'audio',
+            'document',
+            'photo',
+            'sticker',
+            'video',
+            'voice',
+            'contact',
+            'location',
+            'venue',
+            'text',
+            'new_chat_member',
+            'left_chat_member',
+            'migrate_to_chat_id',
+        ];
 
         return $object->keys()
             ->intersect($types)
@@ -1136,6 +1283,7 @@ class Api
         if (is_array($params['results'])) {
             $params['results'] = json_encode($params['results']);
         }
+
         return $this->post('answerInlineQuery', $params);
     }
 }

--- a/src/Objects/Message.php
+++ b/src/Objects/Message.php
@@ -14,6 +14,7 @@ namespace Telegram\Bot\Objects;
  * @method int              getForwardDate()            (Optional). For forwarded messages, date the original message was sent in Unix time.
  * @method Message          getReplyToMessage()         (Optional). For replies, the original message. Note that the Message object in this field will not contain further reply_to_message fields even if it itself is a reply.
  * @method string           getText()                   (Optional). For text messages, the actual UTF-8 text of the message.
+ * @method MessageEntity[]  getEntities()               (Optional). For text messages, special entities like usernames, URLs, bot commands, etc. that appear in the text.
  * @method Audio            getAudio()                  (Optional). Message is an audio file, information about the file.
  * @method Document         getDocument()               (Optional). Message is a general file, information about the file.
  * @method PhotoSize[]      getPhoto()                  (Optional). Message is a photo, available sizes of the photo.
@@ -23,8 +24,9 @@ namespace Telegram\Bot\Objects;
  * @method string           getCaption()                (Optional). Caption for the document, photo or video contact.
  * @method Contact          getContact()                (Optional). Message is a shared contact, information about the contact.
  * @method Location         getLocation()               (Optional). Message is a shared location, information about the location.
- * @method User             getNewChatParticipant()     (Optional). A new member was added to the group, information about them (this member may be the bot itself).
- * @method User             getLeftChatParticipant()    (Optional). A member was removed from the group, information about them (this member may be the bot itself).
+ * @method Venue            getVenue()                  (Optional). Message is a venue, information about the venue.
+ * @method User             getNewChatMember()          (Optional). A new member was added to the group, information about them (this member may be the bot itself).
+ * @method User             getLeftChatMember()         (Optional). A member was removed from the group, information about them (this member may be the bot itself).
  * @method string           getNewChatTitle()           (Optional). A chat title was changed to this value.
  * @method PhotoSize[]      getNewChatPhoto()           (Optional). A chat photo was change to this value.
  * @method bool             getDeleteChatPhoto()        (Optional). Service message: the chat photo was deleted.
@@ -33,6 +35,7 @@ namespace Telegram\Bot\Objects;
  * @method bool             getChannelChatCreated()     (Optional). Service message: the channel has been created.
  * @method int              getMigrateToChatId()        (Optional). The group has been migrated to a supergroup with the specified identifier, not exceeding 1e13 by absolute value.
  * @method int              getMigrateFromChatId()      (Optional). The supergroup has been migrated from a group with the specified identifier, not exceeding 1e13 by absolute value.
+ * @method Message          getPinnedMessage()          (Optional). Specified message was pinned. Note that the Message object in this field will not contain further reply_to_message fields even if it is itself a reply.
  */
 class Message extends BaseObject
 {
@@ -42,21 +45,24 @@ class Message extends BaseObject
     public function relations()
     {
         return [
-            'chat'                  => Chat::class,
-            'from'                  => User::class,
-            'forward_from'          => User::class,
-            'reply_to_message'      => self::class,
-            'audio'                 => Audio::class,
-            'document'              => Document::class,
-            'photo'                 => PhotoSize::class,
-            'sticker'               => Sticker::class,
-            'video'                 => Video::class,
-            'voice'                 => Voice::class,
-            'contact'               => Contact::class,
-            'location'              => Location::class,
-            'new_chat_participant'  => User::class,
-            'left_chat_participant' => User::class,
-            'new_chat_photo'        => PhotoSize::class,
+            'from'             => User::class,
+            'chat'             => Chat::class,
+            'forward_from'     => User::class,
+            'reply_to_message' => self::class,
+            'entities'         => MessageEntity::class,
+            'audio'            => Audio::class,
+            'document'         => Document::class,
+            'photo'            => PhotoSize::class,
+            'sticker'          => Sticker::class,
+            'video'            => Video::class,
+            'voice'            => Voice::class,
+            'contact'          => Contact::class,
+            'location'         => Location::class,
+            'venue'            => Venue::class,
+            'new_chat_member'  => User::class,
+            'left_chat_member' => User::class,
+            'new_chat_photo'   => PhotoSize::class,
+            'pinned_message'   => Message::class,
         ];
     }
 }

--- a/src/Objects/MessageEntity.php
+++ b/src/Objects/MessageEntity.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Telegram\Bot\Objects;
+
+/**
+ * Class Location.
+ *
+ *
+ * @method string   getType()   Type of the entity. One of mention (@username), hashtag, bot_command, url, email, bold (bold text), italic (italic text), code (monowidth string), pre (monowidth block), text_link (for clickable text URLs)
+ * @method int      getOffset() Offset in UTF-16 code units to the start of the entity
+ * @method int      getLength() Length of the entity in UTF-16 code units
+ * @method string   getUrl()    (Optional). For "text_link" only, url that will be opened after user taps on the text.
+ */
+class MessageEntity extends BaseObject
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function relations()
+    {
+        return [];
+    }
+}

--- a/src/Objects/Venue.php
+++ b/src/Objects/Venue.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Telegram\Bot\Objects;
+
+/**
+ * Class Venue.
+ *
+ *
+ * @method Location    getLocation()        Venue location.
+ * @method string      getTitle()           Name of the venue.
+ * @method string      getAddress()         Address of the venue.
+ * @method string      getFoursquareId()    (Optional). Foursquare identifier of the venue.
+ */
+class Venue extends BaseObject
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function relations()
+    {
+        return [
+            'location' => Location::class,
+        ];
+    }
+}


### PR DESCRIPTION
New API updates 9th April
Implements the following features:

New methods kickChatMember and unbanChatMember.
Added fields venue, pinned_message and entities to the Message object.
Added new objects MessageEntity and Venue, new methods sendVenue and sendContact.
Renamed the fields new_chat_participant and left_chat_participant of the Message object to new_chat_member and left_chat_member.
