### PR TITLE
Revet regexp

### DIFF
--- a/src/Helpers/Emojify.php
+++ b/src/Helpers/Emojify.php
@@ -158,13 +158,9 @@ class Emojify
      */
     protected function wordToEmojiReplace($line, $replace, $delimiter)
     {
-        $pattern = '/' . preg_quote($delimiter, '/') . '([^' . preg_quote($delimiter, '/') .']*)' . preg_quote($delimiter, '/') . '/';
-        $line = preg_replace_callback($pattern, function ($matches) use ($replace) {
-            if (array_key_exists($matches[1], $replace)) {
-                return $replace[$matches[1]];
-            }
-            return $matches[1];
-        }, $line);
+        foreach ($replace as $key => $value) {
+            $line = str_replace($delimiter.$key.$delimiter, $value, $line);
+        }
 
         return $line;
     }

--- a/src/Helpers/Emojify.php
+++ b/src/Helpers/Emojify.php
@@ -158,7 +158,7 @@ class Emojify
      */
     protected function wordToEmojiReplace($line, $replace, $delimiter)
     {
-        $pattern = '/' . preg_quote($delimiter, '/') . '([^' . preg_quote($delimiter, '/') .']+)' . preg_quote($delimiter, '/') . '/';
+        $pattern = '/' . preg_quote($delimiter, '/') . '([^' . preg_quote($delimiter, '/') .']*)' . preg_quote($delimiter, '/') . '/';
         $line = preg_replace_callback($pattern, function ($matches) use ($replace) {
             if (array_key_exists($matches[1], $replace)) {
                 return $replace[$matches[1]];


### PR DESCRIPTION
I think my regexp is not working and it is impossible to solve this problem efficiently with php implementation of regexp functions.
Here is what that is wrong:

input:
':foo:one:foo'
expected output:
':foo1foo:'
current output:
'fooonefoo'
