### PR TITLE
no emojify in the API

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -15,7 +15,6 @@ use Telegram\Bot\Objects\Update;
 use Telegram\Bot\Objects\User;
 use Telegram\Bot\Objects\UserProfilePhotos;
 use Telegram\Bot\Keyboard\Keyboard;
-use Telegram\Bot\Helpers\Emojify;
 
 /**
  * Class Api.
@@ -77,13 +76,6 @@ class Api
      * @var int
      */
     protected $connectTimeOut = 10;
-
-    /**
-     * Use Emojify for text fields in requests.
-     *
-     * @var bool
-     */
-    protected $useEmojify = true;
 
     /**
      * Instantiates a new Telegram super-class object.
@@ -253,7 +245,6 @@ class Api
      */
     public function sendMessage(array $params)
     {
-        $params = $this->emojify($params, 'text');
         $response = $this->post('sendMessage', $params);
 
         return new Message($response->getDecodedBody());
@@ -318,8 +309,6 @@ class Api
      */
     public function sendPhoto(array $params)
     {
-        $params = $this->emojify($params, 'caption');
-
         return $this->uploadFile('sendPhoto', $params);
     }
 
@@ -388,8 +377,6 @@ class Api
      */
     public function sendDocument(array $params)
     {
-        $params = $this->emojify($params, 'caption');
-
         return $this->uploadFile('sendDocument', $params);
     }
 
@@ -465,8 +452,6 @@ class Api
      */
     public function sendVideo(array $params)
     {
-        $params = $this->emojify($params, 'caption');
-
         return $this->uploadFile('sendVideo', $params);
     }
 
@@ -791,8 +776,6 @@ class Api
      */
     public function answerCallbackQuery(array $params)
     {
-        $params = $this->emojify($params, 'text');
-
         return $this->post('answerCallbackQuery', $params);
     }
 
@@ -827,7 +810,6 @@ class Api
      */
     public function editMessageText(array $params)
     {
-        $params = $this->emojify($params, 'text');
         $response = $this->post('editMessageText', $params);
 
         return new Message($response->getDecodedBody());
@@ -860,7 +842,6 @@ class Api
      */
     public function editMessageCaption(array $params)
     {
-        $params = $this->emojify($params, 'caption');
         $response = $this->post('editMessageCaption', $params);
 
         return new Message($response->getDecodedBody());
@@ -1478,49 +1459,5 @@ class Api
         $this->connectTimeOut = $connectTimeOut;
 
         return $this;
-    }
-
-    /**
-     * Emojify Given Property in Params.
-     *
-     * @param array  $params
-     * @param string $property
-     *
-     * @return mixed
-     */
-    protected function emojify(array $params, $property)
-    {
-        if (!$this->isUseEmojify()) {
-            return $params;
-        }
-        if (isset($params[$property])) {
-            $params[$property] = Emojify::text($params[$property]);
-        }
-
-        return $params;
-    }
-
-    /**
-     * Change the behavior of using Emojify.
-     *
-     * @param bool $useEmojify
-     *
-     * @return Api
-     */
-    public function setUseEmojify($useEmojify)
-    {
-        $this->useEmojify = $useEmojify;
-
-        return $this;
-    }
-
-    /**
-     * Check if Emojify is enabled.
-     *
-     * @return bool
-     */
-    public function isUseEmojify()
-    {
-        return $this->useEmojify;
     }
 }

--- a/src/BotsManager.php
+++ b/src/BotsManager.php
@@ -198,7 +198,6 @@ class BotsManager
 
         $token = array_get($config, 'token');
         $commands = array_get($config, 'commands', []);
-        $useEmojify = array_get($config, 'use_emojify', true);
 
         $telegram = new Api(
             $token,
@@ -215,11 +214,6 @@ class BotsManager
 
         // Register Commands
         $telegram->addCommands($commands);
-
-        // Use Emojify
-        if (!$useEmojify) {
-            $telegram->setUseEmojify(false);
-        }
 
         return $telegram;
     }

--- a/src/Keyboard/Button.php
+++ b/src/Keyboard/Button.php
@@ -1,8 +1,6 @@
 <?php
 namespace Telegram\Bot\Keyboard;
 
-use Telegram\Bot\Helpers\Emojify;
-
 /**
  * Class Button
  *
@@ -24,7 +22,7 @@ class Button extends Base
      */
     public function setText($text)
     {
-        $this->items['text'] = Emojify::text($text);
+        $this->items['text'] = $text;
 
         return $this;
     }

--- a/src/Keyboard/Keyboard.php
+++ b/src/Keyboard/Keyboard.php
@@ -1,8 +1,6 @@
 <?php
 namespace Telegram\Bot\Keyboard;
 
-use Telegram\Bot\Helpers\Emojify;
-
 /**
  * Class Keyboard
  *
@@ -110,7 +108,7 @@ class Keyboard extends Base
     public static function button($params = [])
     {
         if (is_string($params)) {
-            return Emojify::text($params);
+            return $params;
         }
 
         return Button::make($params);

--- a/src/Laravel/config/telegram.php
+++ b/src/Laravel/config/telegram.php
@@ -37,8 +37,6 @@ return [
     |               Acme\Project\Commands\BotFather\HelloCommand::class,
     |               Acme\Project\Commands\BotFather\ByeCommand::class,
     |             ]
-    | - use_emojify: Ability to disable using Emojify by default.
-    |
     */
     'bots' => [
         'common' => [
@@ -47,7 +45,6 @@ return [
             'commands' => [
 //                Acme\Project\Commands\MyTelegramBot\BotCommand::class
             ],
-            'use_emojify' => env('TELEGRAM_USE_EMOJIFY', true),
         ],
 
 //        'second' => [

--- a/src/Objects/Message.php
+++ b/src/Objects/Message.php
@@ -2,8 +2,6 @@
 
 namespace Telegram\Bot\Objects;
 
-use Telegram\Bot\Helpers\Emojify;
-
 /**
  * Class Message.
  *
@@ -73,7 +71,7 @@ class Message extends BaseObject
      */
     public function getText()
     {
-        return Emojify::translate($this->get('text'));
+        return $this->get('text');
     }
 
     /**
@@ -83,7 +81,7 @@ class Message extends BaseObject
      */
     public function getCaption()
     {
-        return Emojify::translate($this->get('caption'));
+        return $this->get('caption');
     }
 
 }

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -442,14 +442,6 @@ class ApiTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(200, $response->getHttpStatusCode());
     }
 
-    /** @test * */
-    public function it_ensures_ability_to_disable_using_emojify_by_default()
-    {
-        $this->assertTrue($this->api->isUseEmojify());
-        $this->api->setUseEmojify(false);
-        $this->assertNotTrue($this->api->isUseEmojify());
-    }
-
     /**
      * A list of files/attachments types that should be tested.
      *


### PR DESCRIPTION
It is nice to have some Emoji support. But IMHO, it should be there to be used in the presentation layer. The API layer should not get dirty with it at all. For the performance issues, we can still work on it if we want to.

Sorry for the last PR by the way.