### PR TITLE
Update CommandInterface

### DIFF
--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -156,9 +156,9 @@ abstract class Command implements CommandInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
-    public function make($telegram, $arguments, $update)
+    public function make(Api $telegram, $arguments, Update $update)
     {
         $this->telegram = $telegram;
         $this->arguments = $arguments;

--- a/src/Commands/CommandInterface.php
+++ b/src/Commands/CommandInterface.php
@@ -2,28 +2,50 @@
 
 namespace Telegram\Bot\Commands;
 
+use Telegram\Bot\Api;
+use Telegram\Bot\Objects\Update;
+
 /**
  * Interface CommandInterface.
  */
 interface CommandInterface
 {
     /**
-     * Process Inbound Command.
+     * Get Command Name.
      *
-     * @param $telegram
-     * @param $arguments
-     * @param $update
+     * The name of the Telegram command.
+     * Ex: help - Whenever the user sends /help, this would be resolved.
      *
-     * @return mixed
+     * @return string
      */
-    public function make($telegram, $arguments, $update);
+    public function getName();
 
     /**
-     * Process the command.
+     * Get Command Aliases
      *
-     * @param $arguments
+     * Helpful when you want to trigger command with more than one name.
+     *
+     * @return array
+     */
+    public function getAliases();
+
+    /**
+     * Get Command Description.
+     *
+     * The Telegram command description.
+     *
+     * @return string
+     */
+    public function getDescription();
+
+    /**
+     * Process Inbound Command.
+     *
+     * @param Api $telegram
+     * @param string $arguments
+     * @param Update $update
      *
      * @return mixed
      */
-    public function handle($arguments);
+    public function make(Api $telegram, $arguments, Update $update);
 }

--- a/tests/CommandBusTest.php
+++ b/tests/CommandBusTest.php
@@ -129,7 +129,7 @@ class CommandBusTest extends \PHPUnit_Framework_TestCase
         $command = new MockCommand();
         $this->commandBus->addCommand($command);
 
-        $res = $this->commandBus->execute('mycommand', '', Mocker::createUpdateResponse());
+        $res = $this->commandBus->execute('mycommand', '', Mocker::createUpdateObject()->reveal());
 
         $this->assertEquals('mycommand handled', $res);
     }


### PR DESCRIPTION
Fix https://github.com/irazasyed/telegram-bot-sdk/issues/168

Also remove `hande` method as it used only in `\Telegram\Bot\Commands\Command` and can not be executed without `make` method (because `telegram` and `update` properties are initialized there)

And add type hinting to make method