### PR TITLE
Inject Api object into UpdateWasReceived event

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -968,7 +968,7 @@ class Api
         $update = new Update($body);
 
         if ($emitUpdateWasReceivedEvent) {
-            $this->emitEvent(new UpdateWasReceived($update));
+            $this->emitEvent(new UpdateWasReceived($update, $this));
         }
 
         return $update;
@@ -1019,7 +1019,7 @@ class Api
                 $update = new Update($body);
 
                 if ($emitUpdateWasReceivedEvents) {
-                    $this->emitEvent(new UpdateWasReceived($update));
+                    $this->emitEvent(new UpdateWasReceived($update, $this));
                 }
 
                 $data[] = $update;

--- a/src/Events/UpdateWasReceived.php
+++ b/src/Events/UpdateWasReceived.php
@@ -3,6 +3,7 @@
 namespace Telegram\Bot\Events;
 
 use League\Event\AbstractEvent;
+use Telegram\Bot\Api;
 use Telegram\Bot\Objects\Update;
 
 class UpdateWasReceived extends AbstractEvent
@@ -13,12 +14,20 @@ class UpdateWasReceived extends AbstractEvent
     private $update;
 
     /**
-     * UpdateWasReceived constructor.
-     * @param Update $update
+     * @var Api
      */
-    public function __construct(Update $update)
+    private $telegram;
+
+    /**
+     * UpdateWasReceived constructor.
+     *
+     * @param Update $update
+     * @param Api    $telegram
+     */
+    public function __construct(Update $update, Api $telegram)
     {
         $this->update = $update;
+        $this->telegram = $telegram;
     }
 
     /**
@@ -27,5 +36,13 @@ class UpdateWasReceived extends AbstractEvent
     public function getUpdate()
     {
         return $this->update;
+    }
+
+    /**
+     * @return Api
+     */
+    public function getTelegram()
+    {
+        return $this->telegram;
     }
 }


### PR DESCRIPTION
We need this to be able to call api methods inside other packages which listen to `UpdateWasReceived` event.

E.g. https://github.com/irazasyed/telegram-bot-sdk/blob/master/src/Answers/Answerable.php is used by https://github.com/telegram-bot-kit/talk and of course it needs to be able to make API calls.