### PR TITLE
Move type detection from Api class to Message and Update.

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -1180,64 +1180,60 @@ class Api
     /**
      * Determine if a given type is the message.
      *
+     * @deprecated Call method isType directly on Message object
+     *             To be removed in next major version.
+     * 
      * @param string         $type
      * @param Update|Message $object
      *
+     * @throws \InvalidArgumentException
+     * 
      * @return bool
      */
     public function isMessageType($type, $object)
     {
+        if($object === null){
+            return null;
+        }
+        
         if ($object instanceof Update) {
-            $object = $object->getMessage();
+            if($object->has('message')){
+                $object = $object->getMessage();
+            }else{
+                throw new \InvalidArgumentException('The object must be or contain a message');
+            }
         }
-
-        if ($object->has(strtolower($type))) {
-            return true;
-        }
-
-        return $this->detectMessageType($object) === $type;
+        
+        return $object->isType($type);
     }
 
     /**
      * Detect Message Type Based on Update or Message Object.
+     * 
+     * @deprecated Call method detectType directly on Message object
+     *             To be removed in next major version.
      *
      * @param Update|Message $object
+     * 
+     * @throws \InvalidArgumentException
      *
      * @return string|null
      */
     public function detectMessageType($object)
     {
+        if($object === null){
+            return null;
+        }
+        
         if ($object instanceof Update) {
-            $object = $object->getMessage();
+            if($object->has('message')){
+                $object = $object->getMessage();
+            }else{
+                throw new \InvalidArgumentException('The object must be or contain a message');
+            }
         }
 
-        $types = [
-            'text',
-            'audio',
-            'document',
-            'photo',
-            'sticker',
-            'video',
-            'voice',
-            'contact',
-            'location',
-            'venue',
-            'new_chat_member',
-            'left_chat_member',
-            'new_chat_title',
-            'new_chat_photo',
-            'delete_chat_photo',
-            'group_chat_created',
-            'supergroup_chat_created',
-            'channel_chat_created',
-            'migrate_to_chat_id',
-            'migrate_from_chat_id',
-            'pinned_message',
-        ];
-
-        return $object->keys()
-            ->intersect($types)
-            ->pop();
+        return $object->detectType();
     }
 
     /**

--- a/src/Api.php
+++ b/src/Api.php
@@ -1192,7 +1192,7 @@ class Api
      */
     public function isMessageType($type, $object)
     {
-        if($object === null){
+        if ($object === null) {
             return null;
         }
         

--- a/src/Api.php
+++ b/src/Api.php
@@ -1182,12 +1182,12 @@ class Api
      *
      * @deprecated Call method isType directly on Message object
      *             To be removed in next major version.
-     * 
+     *
      * @param string         $type
      * @param Update|Message $object
      *
      * @throws \InvalidArgumentException
-     * 
+     *
      * @return bool
      */
     public function isMessageType($type, $object)
@@ -1197,7 +1197,7 @@ class Api
         }
         
         if ($object instanceof Update) {
-            if($object->has('message')){
+            if ($object->has('message')) {
                 $object = $object->getMessage();
             }else{
                 throw new \InvalidArgumentException('The object must be or contain a message');
@@ -1209,26 +1209,26 @@ class Api
 
     /**
      * Detect Message Type Based on Update or Message Object.
-     * 
+     *
      * @deprecated Call method detectType directly on Message object
      *             To be removed in next major version.
      *
      * @param Update|Message $object
-     * 
+     *
      * @throws \InvalidArgumentException
      *
      * @return string|null
      */
     public function detectMessageType($object)
     {
-        if($object === null){
+        if ($object === null) {
             return null;
         }
         
         if ($object instanceof Update) {
-            if($object->has('message')){
+            if ($object->has('message')) {
                 $object = $object->getMessage();
-            }else{
+            } else {
                 throw new \InvalidArgumentException('The object must be or contain a message');
             }
         }

--- a/src/Objects/Message.php
+++ b/src/Objects/Message.php
@@ -87,7 +87,6 @@ class Message extends BaseObject
     /**
      * Determine if the message is of given type
      *
-     * 
      * @param string         $type
      *
      * @return bool

--- a/src/Objects/Message.php
+++ b/src/Objects/Message.php
@@ -83,5 +83,58 @@ class Message extends BaseObject
     {
         return $this->get('caption');
     }
+    
+    /**
+     * Determine if the message is of given type
+     *
+     * 
+     * @param string         $type
+     *
+     * @return bool
+     */
+    public function isType($type)
+    {
+        if ($this->has(strtolower($type))) {
+            return true;
+        }
 
+        return $this->detectType() === $type;
+    }
+    
+    
+    /**
+     * Detect type based on properties.
+     *
+     * @return string|null
+     */
+    public function detectType()
+    {
+        $types = [
+            'text',
+            'audio',
+            'document',
+            'photo',
+            'sticker',
+            'video',
+            'voice',
+            'contact',
+            'location',
+            'venue',
+            'new_chat_member',
+            'left_chat_member',
+            'new_chat_title',
+            'new_chat_photo',
+            'delete_chat_photo',
+            'group_chat_created',
+            'supergroup_chat_created',
+            'channel_chat_created',
+            'migrate_to_chat_id',
+            'migrate_from_chat_id',
+            'pinned_message',
+        ];
+
+        return $this->keys()
+            ->intersect($types)
+            ->pop();
+    }
 }

--- a/src/Objects/Update.php
+++ b/src/Objects/Update.php
@@ -38,4 +38,40 @@ class Update extends BaseObject
     {
         return new static($this->last());
     }
+    
+    /**
+     * Determine if the update is of given type
+     *
+     * 
+     * @param string         $type
+     *
+     * @return bool
+     */
+    public function isType($type)
+    {
+        if ($this->has(strtolower($type))) {
+            return true;
+        }
+
+        return $this->detectType() === $type;
+    }    
+    
+    /**
+     * Detect type based on properties.
+     *
+     * @return string|null
+     */
+    public function detectType()
+    {
+        $types = [
+            'message',
+            'inline_query',
+            'chosen_inline_result',
+            'callback_query',
+        ];
+
+        return $this->keys()
+            ->intersect($types)
+            ->pop();
+    }
 }

--- a/src/Objects/Update.php
+++ b/src/Objects/Update.php
@@ -42,7 +42,6 @@ class Update extends BaseObject
     /**
      * Determine if the update is of given type
      *
-     * 
      * @param string         $type
      *
      * @return bool
@@ -52,9 +51,9 @@ class Update extends BaseObject
         if ($this->has(strtolower($type))) {
             return true;
         }
-
+    
         return $this->detectType() === $type;
-    }    
+    }
     
     /**
      * Detect type based on properties.


### PR DESCRIPTION
In line with our chat discussion:
- Detection of message type should be concern of Message object --> Moved there
- Detection of Update object added
- Made Api methods more robust against error or updates without message
- Deprecated Api methods


Am i doing this right? (first time github)

Questions:
- Why is `$message->isType` not just an alias for `$message->has`. What does the extra `return $this->detectType() === $type;` add?
- `Api->detectMessageType` was (and is) untested. I honestly do not really know how to test, cause in the end you only test if $update->keys() is implemented correctly. Maybe we need some recorded(?) telegram updates to use as test input.