### PR TITLE
[WIP] Move non-API concerns out of Api

### DIFF
--- a/src/Answers/AnswerBus.php
+++ b/src/Answers/AnswerBus.php
@@ -2,6 +2,7 @@
 
 namespace Telegram\Bot\Answers;
 
+use Telegram\Bot\Bots\Bot;
 use Telegram\Bot\Api;
 
 /**
@@ -10,9 +11,9 @@ use Telegram\Bot\Api;
 abstract class AnswerBus
 {
     /**
-     * @var Api
+     * @var Bot
      */
-    protected $telegram;
+    protected $bot;
 
     /**
      * Handle calls to missing methods.
@@ -38,7 +39,15 @@ abstract class AnswerBus
      */
     public function getTelegram()
     {
-        return $this->telegram;
+        return $this->getBot()->getApi();
+    }
+    
+    /**
+     * @return Bot
+     */
+    public function getBot()
+    {
+        return $this->bot;
     }
 
     /**

--- a/src/Answers/AnswerBus.php
+++ b/src/Answers/AnswerBus.php
@@ -74,7 +74,7 @@ abstract class AnswerBus
         }
 
         // otherwise fetch each dependency out of the container
-        $container = $this->telegram->getContainer();
+        $container = $this->getTelegram()->getContainer();
         $dependencies = [];
         foreach ($params as $param) {
             $dependencies[] = $container->make($param->getClass()->name);

--- a/src/Answers/Answerable.php
+++ b/src/Answers/Answerable.php
@@ -4,6 +4,7 @@ namespace Telegram\Bot\Answers;
 
 use Telegram\Bot\Api;
 use Telegram\Bot\Objects\Update;
+use Telegram\Bot\Bots\Bot;
 
 /**
  * Class Answer
@@ -21,9 +22,9 @@ use Telegram\Bot\Objects\Update;
 trait Answerable
 {
     /**
-     * @var Api Holds the Super Class Instance.
+     * @var Bot Holds the bot instance
      */
-    protected $telegram;
+    protected $bot;
 
     /**
      * @var Update Holds an Update object.
@@ -45,17 +46,17 @@ trait Answerable
             $reply_name = studly_case(substr($method, 9));
             $methodName = 'send' . $reply_name;
 
-            if (!method_exists($this->telegram, $methodName)) {
+            if (!method_exists($this->getTelegram(), $methodName)) {
                 throw new \BadMethodCallException("Method [$method] does not exist.");
             }
 
             $chat_id = $this->update->getMessage()->getChat()->getId();
             $params = array_merge(compact('chat_id'), $arguments[0]);
 
-            return call_user_func_array([$this->telegram, $methodName], [$params]);
+            return call_user_func_array([$this->getTelegram(), $methodName], [$params]);
         }
 
-        throw new \BadMethodCallException("Method [$method] does not exist.");
+        return call_user_func_array([$this->getBot(), $method], $parameters);
     }
 
     /**
@@ -63,7 +64,7 @@ trait Answerable
      */
     public function getTelegram()
     {
-        return $this->telegram;
+        return $this->getBot()->getApi();
     }
 
     /**
@@ -72,5 +73,13 @@ trait Answerable
     public function getUpdate()
     {
         return $this->update;
+    }
+    
+    /**
+     * @return Bot
+     */
+    public function getBot()
+    {
+        return $this->bot;
     }
 }

--- a/src/Api.php
+++ b/src/Api.php
@@ -1081,7 +1081,7 @@ class Api
         return Keyboard::forceReply($params);
     }
     
-    public function confirmUpdate($highestUpdateId){        
+    public function confirmUpdate($highestUpdateId) {
         $params = [];
         $params['offset'] = $highestUpdateId + 1;
         $params['limit'] = 1;
@@ -1110,7 +1110,7 @@ class Api
         if ($object instanceof Update) {
             if ($object->has('message')) {
                 $object = $object->getMessage();
-            }else{
+            } else {
                 throw new \InvalidArgumentException('The object must be or contain a message');
             }
         }

--- a/src/Api.php
+++ b/src/Api.php
@@ -1081,7 +1081,8 @@ class Api
         return Keyboard::forceReply($params);
     }
     
-    public function confirmUpdate($highestUpdateId) {
+    public function confirmUpdate($highestUpdateId)
+    {
         $params = [];
         $params['offset'] = $highestUpdateId + 1;
         $params['limit'] = 1;
@@ -1184,7 +1185,6 @@ class Api
         if ($fileUpload) {
             $params = ['multipart' => $params];
         } else {
-
             if (array_key_exists('reply_markup', $params)) {
                 $params['reply_markup'] = (string)$params['reply_markup'];
             }

--- a/src/Api.php
+++ b/src/Api.php
@@ -1290,10 +1290,6 @@ class Api
      */
     public function __call($method, $arguments)
     {
-//        if (preg_match('/^\w+Commands?/', $method, $matches)) {
-//            return call_user_func_array([$this->getCommandBus(), $matches[0]], $arguments);
-//        }
-
         $action = substr($method, 0, 3);
         if ($action === 'get') {
             /* @noinspection PhpUndefinedFunctionInspection */

--- a/src/Api.php
+++ b/src/Api.php
@@ -3,9 +3,6 @@
 namespace Telegram\Bot;
 
 use Illuminate\Contracts\Container\Container;
-use Telegram\Bot\Commands\CommandBus;
-use Telegram\Bot\Events\EmitsEvents;
-use Telegram\Bot\Events\UpdateWasReceived;
 use Telegram\Bot\Exceptions\TelegramSDKException;
 use Telegram\Bot\FileUpload\InputFile;
 use Telegram\Bot\HttpClients\HttpClientInterface;
@@ -24,8 +21,6 @@ use Telegram\Bot\Keyboard\Keyboard;
  */
 class Api
 {
-    use EmitsEvents;
-
     /**
      * @var string Version number of the Telegram Bot PHP SDK.
      */
@@ -55,11 +50,6 @@ class Api
      * @var bool Indicates if the request to Telegram will be asynchronous (non-blocking).
      */
     protected $isAsyncRequest = false;
-
-    /**
-     * @var CommandBus|null Telegram Command Bus.
-     */
-    protected $commandBus = null;
 
     /**
      * @var Container IoC Container
@@ -103,7 +93,6 @@ class Api
         }
 
         $this->client = new TelegramClient($httpClientHandler);
-        $this->commandBus = new CommandBus($this);
     }
 
     /**
@@ -190,16 +179,6 @@ class Api
     public function isAsyncRequest()
     {
         return $this->isAsyncRequest;
-    }
-
-    /**
-     * Returns SDK's Command Bus.
-     *
-     * @return CommandBus
-     */
-    public function getCommandBus()
-    {
-        return $this->commandBus;
     }
 
     /**
@@ -961,17 +940,11 @@ class Api
      *
      * @return Update
      */
-    public function getWebhookUpdates($emitUpdateWasReceivedEvent = true)
+    public function getWebhookUpdates()
     {
         $body = json_decode(file_get_contents('php://input'), true);
 
-        $update = new Update($body);
-
-        if ($emitUpdateWasReceivedEvent) {
-            $this->emitEvent(new UpdateWasReceived($update, $this));
-        }
-
-        return $update;
+        return new Update($body);
     }
 
     /**
@@ -1000,14 +973,13 @@ class Api
      * @link https://core.telegram.org/bots/api#getupdates
      *
      * @param array  $params
-     * @param bool  $emitUpdateWasReceivedEvents
      * @var int|null $params ['offset']
      * @var int|null $params ['limit']
      * @var int|null $params ['timeout']
      *
      * @return Update[]
      */
-    public function getUpdates(array $params = [], $emitUpdateWasReceivedEvents = true)
+    public function getUpdates(array $params = [])
     {
         $response = $this->post('getUpdates', $params);
         $updates = $response->getDecodedBody();
@@ -1016,13 +988,7 @@ class Api
         $data = [];
         if (isset($updates['result'])) {
             foreach ($updates['result'] as $body) {
-                $update = new Update($body);
-
-                if ($emitUpdateWasReceivedEvents) {
-                    $this->emitEvent(new UpdateWasReceived($update, $this));
-                }
-
-                $data[] = $update;
+                $data[] = new Update($body);
             }
         }
 
@@ -1114,67 +1080,12 @@ class Api
     {
         return Keyboard::forceReply($params);
     }
-
-    /**
-     * Processes Inbound Commands.
-     *
-     * @param bool $webhook
-     *
-     * @return Update|Update[]
-     */
-    public function commandsHandler($webhook = false)
-    {
-        if ($webhook) {
-            $update = $this->getWebhookUpdates();
-            $this->processCommand($update);
-
-            return $update;
-        }
-
-        $updates = $this->getUpdates();
-        $highestId = -1;
-
-        foreach ($updates as $update) {
-            $highestId = $update->getUpdateId();
-            $this->processCommand($update);
-        }
-
-        //An update is considered confirmed as soon as getUpdates is called with an offset higher than its update_id.
-        if ($highestId != -1) {
-            $params = [];
-            $params['offset'] = $highestId + 1;
-            $params['limit'] = 1;
-            $this->getUpdates($params);
-        }
-
-        return $updates;
-    }
-
-    /**
-     * Check update object for a command and process.
-     *
-     * @param Update $update
-     */
-    public function processCommand(Update $update)
-    {
-        $message = $update->getMessage();
-
-        if ($message !== null && $message->has('text')) {
-            $this->getCommandBus()->handler($message->getText(), $update);
-        }
-    }
-
-    /**
-     * Helper to Trigger Commands.
-     *
-     * @param string $name   Command Name
-     * @param Update $update Update Object
-     *
-     * @return mixed
-     */
-    public function triggerCommand($name, Update $update)
-    {
-        return $this->getCommandBus()->execute($name, $update->getMessage()->getText(), $update);
+    
+    public function confirmUpdate($highestUpdateId){        
+        $params = [];
+        $params['offset'] = $highestUpdateId + 1;
+        $params['limit'] = 1;
+        $this->getUpdates($params);
     }
 
     /**
@@ -1379,9 +1290,9 @@ class Api
      */
     public function __call($method, $arguments)
     {
-        if (preg_match('/^\w+Commands?/', $method, $matches)) {
-            return call_user_func_array([$this->getCommandBus(), $matches[0]], $arguments);
-        }
+//        if (preg_match('/^\w+Commands?/', $method, $matches)) {
+//            return call_user_func_array([$this->getCommandBus(), $matches[0]], $arguments);
+//        }
 
         $action = substr($method, 0, 3);
         if ($action === 'get') {

--- a/src/Bots/Bot.php
+++ b/src/Bots/Bot.php
@@ -13,18 +13,18 @@ class Bot
     use EmitsEvents;
     
     /**
-     * @var Api Telegram Api 
+     * @var Api Telegram Api
      */
     protected $api = null;
     
     /**
-     * @var string Name of the bot 
+     * @var string Name of the bot
      */
     protected $name = null;
     
     /**
      * Creates new bot instance and corresponding Api if not given.
-     * 
+     *
      * @param string $name (Optional) Bot name
      * @param Api $api (Optional) Custom Api
      */
@@ -42,7 +42,7 @@ class Bot
     }
     
     /**
-     * @return Api 
+     * @return Api
      */
     public function getApi()
     {
@@ -50,7 +50,7 @@ class Bot
     }
     
     /**
-     * @return string 
+     * @return string
      */
     public function getName()
     {
@@ -67,7 +67,7 @@ class Bot
     
     /**
      * Checks for pending telegram updates. If available, they get read, processed, confirmed and returned.
-     * 
+     *
      * @param boolean $webhook Signals to read update from webhook.
      * @param array $params See Api->getUpdates()
      * @return Update[]
@@ -94,9 +94,9 @@ class Bot
     
     /**
      * Process the Update. Here, emit a corresponding UpdateWasReceived Event.
-     * 
+     *
      * @param type $update
-     */    
+     */
     public function processUpdate($update)
     {
         $this->emitEvent(new UpdateWasReceived($update, $this));
@@ -104,7 +104,7 @@ class Bot
     
     /**
      * Adds a listener to be notified if an update was received.
-     * 
+     *
      * @param ListenerInterface|callable $listener
      */
     public function addUpdateListener($listener)

--- a/src/Bots/Bot.php
+++ b/src/Bots/Bot.php
@@ -45,20 +45,22 @@ class Bot{
             $updates = $this->api->getWebhookUpdates();
         }else{
             $updates = $this->api->getUpdates($params);
-        }        
-        $this->processUpdates($updates);
+        }
         
-        $highestUpdateId = $updates[count($updates) - 1]->getUpdateId();
-        if ($highestUpdateId != -1) {
-            $this->api->confirmUpdate($highestUpdateId);
+        $highestId = -1;
+        foreach ($updates as $update){            
+            $this->processUpdate($update);
+            $highestId = $update->getUpdateId();
+        }
+        
+        if ($highestId != -1) {
+            $this->api->confirmUpdate($highestId);
         }
         return $updates;
     }
     
-    function processUpdates($updates){
-        foreach ($updates as $update){
-            $this->emitEvent(new UpdateWasReceived($update, $this));
-        }
+    function processUpdate($update){        
+        $this->emitEvent(new UpdateWasReceived($update, $this));
     }
     
     function addUpdateListener($listener){

--- a/src/Bots/Bot.php
+++ b/src/Bots/Bot.php
@@ -7,20 +7,33 @@ use Telegram\Bot\Api;
 use Telegram\Bot\Events\UpdateWasReceived;
 use Telegram\Bot\Events\EmitsEvents;
 
-class Bot{
+class Bot
+{
         
     use EmitsEvents;
     
+    /**
+     * @var Api Telegram Api 
+     */
     protected $api = null;
     
+    /**
+     * @var string Name of the bot 
+     */
     protected $name = null;
     
+    /**
+     * Creates new bot instance and corresponding Api if not given.
+     * 
+     * @param string $name (Optional) Bot name
+     * @param Api $api (Optional) Custom Api
+     */
     public function __construct($name = null, Api $api = null)
     {
         
-        if($api === null){
+        if ($api === null) {
             $this->api = new Api();
-        }else{
+        } else {
             $this->api = $api;
         }
         
@@ -28,27 +41,47 @@ class Bot{
         $this->setEventEmitter(new Emitter());
     }
     
-    public function getApi(){
+    /**
+     * @return Api 
+     */
+    public function getApi()
+    {
         return $this->api;
     }
     
-    public function getName(){
+    /**
+     * @return string 
+     */
+    public function getName()
+    {
         return $this->name;
     }
     
-    public function setName($name){
+    /**
+     * @param string $name
+     */
+    public function setName($name)
+    {
         $this->name = $name;
     }
     
-    public function checkForUpdates($webhook = false, $params = []){
-        if($webhook){
+    /**
+     * Checks for pending telegram updates. If available, they get read, processed, confirmed and returned.
+     * 
+     * @param boolean $webhook Signals to read update from webhook.
+     * @param array $params See Api->getUpdates()
+     * @return Update[]
+     */
+    public function checkForUpdates($webhook = false, $params = [])
+    {
+        if ($webhook) {
             $updates = $this->api->getWebhookUpdates();
-        }else{
+        } else {
             $updates = $this->api->getUpdates($params);
         }
         
         $highestId = -1;
-        foreach ($updates as $update){            
+        foreach ($updates as $update) {
             $this->processUpdate($update);
             $highestId = $update->getUpdateId();
         }
@@ -59,11 +92,23 @@ class Bot{
         return $updates;
     }
     
-    function processUpdate($update){        
+    /**
+     * Process the Update. Here, emit a corresponding UpdateWasReceived Event.
+     * 
+     * @param type $update
+     */    
+    public function processUpdate($update)
+    {
         $this->emitEvent(new UpdateWasReceived($update, $this));
     }
     
-    function addUpdateListener($listener){
+    /**
+     * Adds a listener to be notified if an update was received.
+     * 
+     * @param ListenerInterface|callable $listener
+     */
+    public function addUpdateListener($listener)
+    {
         $this->getEventEmitter()->addListener(UpdateWasReceived::class, $listener);
     }
     
@@ -79,5 +124,4 @@ class Bot{
     {
         return call_user_func_array([$this->getApi(), $method], $parameters);
     }
-    
 }

--- a/src/Bots/Bot.php
+++ b/src/Bots/Bot.php
@@ -48,10 +48,11 @@ class Bot{
         }        
         $this->processUpdates($updates);
         
-        $highestUpdateId = $updates->last()->getUpdateId();
+        $highestUpdateId = $updates[count($updates) - 1]->getUpdateId();
         if ($highestUpdateId != -1) {
             $this->api->confirmUpdate($highestUpdateId);
         }
+        return $updates;
     }
     
     function processUpdates($updates){
@@ -62,6 +63,19 @@ class Bot{
     
     function addUpdateListener($listener){
         $this->getEventEmitter()->addListener(UpdateWasReceived::class, $listener);
+    }
+    
+    /**
+     * Magically pass methods to the api.
+     *
+     * @param string $method
+     * @param array  $parameters
+     *
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        return call_user_func_array([$this->getApi(), $method], $parameters);
     }
     
 }

--- a/src/Bots/Bot.php
+++ b/src/Bots/Bot.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Telegram\Bot\Bots;
+
+use League\Event\Emitter;
+use Telegram\Bot\Api;
+use Telegram\Bot\Events\UpdateWasReceived;
+use Telegram\Bot\Events\EmitsEvents;
+
+class Bot{
+        
+    use EmitsEvents;
+    
+    protected $api = null;
+    
+    protected $name = null;
+    
+    public function __construct($name = null, Api $api = null)
+    {
+        
+        if($api === null){
+            $this->api = new Api();
+        }else{
+            $this->api = $api;
+        }
+        
+        $this->name = $name;
+        $this->setEventEmitter(new Emitter());
+    }
+    
+    public function getApi(){
+        return $this->api;
+    }
+    
+    public function getName(){
+        return $this->name;
+    }
+    
+    public function setName($name){
+        $this->name = $name;
+    }
+    
+    public function checkForUpdates($webhook = false, $params = []){
+        if($webhook){
+            $updates = $this->api->getWebhookUpdates();
+        }else{
+            $updates = $this->api->getUpdates($params);
+        }        
+        $this->processUpdates($updates);
+        
+        $highestUpdateId = $updates->last()->getUpdateId();
+        if ($highestUpdateId != -1) {
+            $this->api->confirmUpdate($highestUpdateId);
+        }
+    }
+    
+    function processUpdates($updates){
+        foreach ($updates as $update){
+            $this->emitEvent(new UpdateWasReceived($update, $this));
+        }
+    }
+    
+    function addUpdateListener($listener){
+        $this->getEventEmitter()->addListener(UpdateWasReceived::class, $listener);
+    }
+    
+}

--- a/src/Bots/BotsManager.php
+++ b/src/Bots/BotsManager.php
@@ -201,13 +201,12 @@ class BotsManager
         $token = array_get($config, 'token');
         $commands = array_get($config, 'commands', []);
 
-        $bot = new CommandBot($name,
-                new Api(
-                    $token,
-                    $this->getConfig('async_requests', false),
-                    $this->getConfig('http_client_handler', null)
-                )
+        $api = new Api(
+            $token,
+            $this->getConfig('async_requests', false),
+            $this->getConfig('http_client_handler', null)
         );
+        $bot = new CommandBot($name, $api);
 
         // Check if DI needs to be enabled for Commands
         if ($this->getConfig('resolve_command_dependencies', false) && isset($this->container)) {

--- a/src/Bots/BotsManager.php
+++ b/src/Bots/BotsManager.php
@@ -5,7 +5,7 @@ namespace Telegram\Bot\Bots;
 use Illuminate\Contracts\Container\Container;
 use InvalidArgumentException;
 use Telegram\Bot\Api;
-use Telegram\Commands\CommandBot;
+use Telegram\Bot\Commands\CommandBot;
 
 /**
  * Class BotsManager

--- a/src/Bots/BotsManager.php
+++ b/src/Bots/BotsManager.php
@@ -4,6 +4,7 @@ namespace Telegram\Bot\Bots;
 
 use Illuminate\Contracts\Container\Container;
 use InvalidArgumentException;
+use Telegram\Bot\Api;
 
 /**
  * Class BotsManager
@@ -29,7 +30,7 @@ class BotsManager
     /**
      * The active bot instances.
      *
-     * @var Api[]
+     * @var Bot[]
      */
     protected $bots = [];
 
@@ -85,7 +86,7 @@ class BotsManager
      *
      * @param string $name
      *
-     * @return Api
+     * @return Bot
      */
     public function bot($name = null)
     {
@@ -103,7 +104,7 @@ class BotsManager
      *
      * @param string $name
      *
-     * @return Api
+     * @return Bot
      */
     public function reconnect($name = null)
     {
@@ -166,7 +167,7 @@ class BotsManager
     /**
      * Return all of the created bots.
      *
-     * @return Api[]
+     * @return Bot[]
      */
     public function getBots()
     {
@@ -190,7 +191,7 @@ class BotsManager
      *
      * @param string $name
      *
-     * @return Api
+     * @return Bot
      */
     protected function makeBot($name)
     {
@@ -199,23 +200,25 @@ class BotsManager
         $token = array_get($config, 'token');
         $commands = array_get($config, 'commands', []);
 
-        $telegram = new Api(
-            $token,
-            $this->getConfig('async_requests', false),
-            $this->getConfig('http_client_handler', null)
+        $bot = new CommandBot($name,
+                new Api(
+                    $token,
+                    $this->getConfig('async_requests', false),
+                    $this->getConfig('http_client_handler', null)
+                )
         );
 
         // Check if DI needs to be enabled for Commands
         if ($this->getConfig('resolve_command_dependencies', false) && isset($this->container)) {
-            $telegram->setContainer($this->container);
+            $bot->getApi()->setContainer($this->container);
         }
 
         $commands = $this->parseBotCommands($commands);
 
         // Register Commands
-        $telegram->addCommands($commands);
+        $bot->addCommands($commands);
 
-        return $telegram;
+        return $bot;
     }
 
     /**

--- a/src/Bots/BotsManager.php
+++ b/src/Bots/BotsManager.php
@@ -5,6 +5,7 @@ namespace Telegram\Bot\Bots;
 use Illuminate\Contracts\Container\Container;
 use InvalidArgumentException;
 use Telegram\Bot\Api;
+use Telegram\Commands\CommandBot;
 
 /**
  * Class BotsManager

--- a/src/Bots/BotsManager.php
+++ b/src/Bots/BotsManager.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Telegram\Bot;
+namespace Telegram\Bot\Bots;
 
 use Illuminate\Contracts\Container\Container;
 use InvalidArgumentException;

--- a/src/Bots/CommandBot.php
+++ b/src/Bots/CommandBot.php
@@ -62,6 +62,13 @@ class CommandBot extends Bot
     {
         return $this->getCommandBus()->execute($name, $update->getMessage()->getText(), $update);
     }
+    
+    public function __call($method, $arguments)
+    {
+        if (preg_match('/^\w+Commands?/', $method, $matches)) {
+            return call_user_func_array([$this->getCommandBus(), $matches[0]], $arguments);
+        }
+    }
 }
     
     

--- a/src/Bots/CommandBot.php
+++ b/src/Bots/CommandBot.php
@@ -19,7 +19,7 @@ class CommandBot extends Bot
     public function __construct($name = null, $api = null)
     {
         parent::__construct($name, $api);
-        $this->commandBus = new CommandBus($this->getApi());
+        $this->commandBus = new CommandBus($this);
         
         $this->addUpdateListener(function(UpdateWasReceived $event){
             $this->processCommand($event->getUpdate());

--- a/src/Bots/CommandBot.php
+++ b/src/Bots/CommandBot.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Telegram\Bot\Bots;
+
+use Telegram\Bot\Commands\CommandBus;
+use Telegram\Bot\Events\UpdateWasReceived;
+use Telegram\Bot\Objects\Update;
+
+
+class CommandBot extends Bot
+{
+    
+    /**
+     * @var CommandBus Telegram Command Bus.
+     */
+    protected $commandBus = null;
+    
+    
+    public function __construct($name = null, $api = null)
+    {
+        parent::__construct($name, $api);
+        $this->commandBus = new CommandBus($this->getApi());
+        
+        $this->addUpdateListener(function(UpdateWasReceived $event){
+            $this->processCommand($event->getUpdate());
+        });
+    }
+    
+    /**
+     * Returns SDK's Command Bus.
+     *
+     * @return CommandBus
+     */
+    public function getCommandBus()
+    {
+        return $this->commandBus;
+    }
+    
+    /**
+     * Check update object for a command and process.
+     *
+     * @param Update $update
+     */
+    public function processCommand(Update $update)
+    {
+        $message = $update->getMessage();
+
+        if ($message !== null && $message->has('text')) {
+            $this->getCommandBus()->handler($message->getText(), $update);
+        }
+    }
+
+    /**
+     * Helper to Trigger Commands.
+     *
+     * @param string $name   Command Name
+     * @param Update $update Update Object
+     *
+     * @return mixed
+     */
+    public function triggerCommand($name, Update $update)
+    {
+        return $this->getCommandBus()->execute($name, $update->getMessage()->getText(), $update);
+    }
+}
+    
+    
+        
+
+       

--- a/src/Bots/CommandBot.php
+++ b/src/Bots/CommandBot.php
@@ -68,6 +68,8 @@ class CommandBot extends Bot
         if (preg_match('/^\w+Commands?/', $method, $matches)) {
             return call_user_func_array([$this->getCommandBus(), $matches[0]], $arguments);
         }
+        
+        return parent::__call($method, $arguments);
     }
 }
     

--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -3,7 +3,7 @@
 namespace Telegram\Bot\Commands;
 
 use Telegram\Bot\Answers\Answerable;
-use Telegram\Bot\Api;
+use Telegram\Bot\Bots\Bot;
 use Telegram\Bot\Objects\Update;
 
 /**
@@ -125,15 +125,15 @@ abstract class Command implements CommandInterface
      */
     public function getCommandBus()
     {
-        return $this->telegram->getCommandBus();
+        return $this->getBot()->getCommandBus();
     }
 
     /**
      * @inheritDoc
      */
-    public function make(Api $telegram, $arguments, Update $update)
+    public function make(Bot $bot, $arguments, Update $update)
     {
-        $this->telegram = $telegram;
+        $this->bot = $bot;
         $this->arguments = $arguments;
         $this->update = $update;
 

--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -131,7 +131,7 @@ abstract class Command implements CommandInterface
     /**
      * @inheritDoc
      */
-    public function make(Bot $bot, $arguments, Update $update)
+    public function make(CommandBot $bot, $arguments, Update $update)
     {
         $this->bot = $bot;
         $this->arguments = $arguments;

--- a/src/Commands/CommandBot.php
+++ b/src/Commands/CommandBot.php
@@ -1,11 +1,10 @@
 <?php
 
-namespace Telegram\Bot\Bots;
+namespace Telegram\Commands;
 
 use Telegram\Bot\Commands\CommandBus;
 use Telegram\Bot\Events\UpdateWasReceived;
 use Telegram\Bot\Objects\Update;
-
 
 class CommandBot extends Bot
 {
@@ -15,13 +14,18 @@ class CommandBot extends Bot
      */
     protected $commandBus = null;
     
-    
+    /**
+     * Creates new Command Bot
+     *
+     * @param string $name (Optional)
+     * @param Api $api (Optional) 
+     */    
     public function __construct($name = null, $api = null)
     {
         parent::__construct($name, $api);
         $this->commandBus = new CommandBus($this);
         
-        $this->addUpdateListener(function(UpdateWasReceived $event){
+        $this->addUpdateListener(function (UpdateWasReceived $event) {
             $this->processCommand($event->getUpdate());
         });
     }
@@ -63,6 +67,13 @@ class CommandBot extends Bot
         return $this->getCommandBus()->execute($name, $update->getMessage()->getText(), $update);
     }
     
+    /**
+     * Magic method to call command related method directly on the CommandBus
+     * 
+     * @param $method
+     * @param $arguments
+     * @return 
+     */
     public function __call($method, $arguments)
     {
         if (preg_match('/^\w+Commands?/', $method, $matches)) {
@@ -72,8 +83,3 @@ class CommandBot extends Bot
         return parent::__call($method, $arguments);
     }
 }
-    
-    
-        
-
-       

--- a/src/Commands/CommandBot.php
+++ b/src/Commands/CommandBot.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace Telegram\Commands;
+namespace Telegram\Bot\Commands;
 
+use Telegram\Bot\Bots\Bot;
 use Telegram\Bot\Commands\CommandBus;
 use Telegram\Bot\Events\UpdateWasReceived;
 use Telegram\Bot\Objects\Update;
@@ -18,8 +19,8 @@ class CommandBot extends Bot
      * Creates new Command Bot
      *
      * @param string $name (Optional)
-     * @param Api $api (Optional) 
-     */    
+     * @param Api $api (Optional)
+     */
     public function __construct($name = null, $api = null)
     {
         parent::__construct($name, $api);
@@ -69,10 +70,10 @@ class CommandBot extends Bot
     
     /**
      * Magic method to call command related method directly on the CommandBus
-     * 
+     *
      * @param $method
      * @param $arguments
-     * @return 
+     * @return
      */
     public function __call($method, $arguments)
     {

--- a/src/Commands/CommandBus.php
+++ b/src/Commands/CommandBus.php
@@ -88,8 +88,8 @@ class CommandBus extends AnswerBus
             }
         }
 
-        if ($command instanceof CommandInterface) {
-
+        if ($command instanceof CommandInterface)
+        {
             /*
              * At this stage we definitely have a proper command to use.
              *

--- a/src/Commands/CommandBus.php
+++ b/src/Commands/CommandBus.php
@@ -3,7 +3,7 @@
 namespace Telegram\Bot\Commands;
 
 use Telegram\Bot\Answers\AnswerBus;
-use Telegram\Bot\Api;
+use Telegram\Bot\Bots\Bot;
 use Telegram\Bot\Objects\Update;
 use Telegram\Bot\Exceptions\TelegramSDKException;
 
@@ -25,13 +25,13 @@ class CommandBus extends AnswerBus
     /**
      * Instantiate Command Bus.
      *
-     * @param Api $telegram
+     * @param Bot $bot
      *
      * @throws TelegramSDKException
      */
-    public function __construct(Api $telegram)
+    public function __construct(Bot $bot)
     {
-        $this->telegram = $telegram;
+        $this->bot = $bot;
     }
 
     /**
@@ -81,7 +81,7 @@ class CommandBus extends AnswerBus
                 );
             }
 
-            if ($this->telegram->hasContainer()) {
+            if ($this->getTelegram()->hasContainer()) {
                 $command = $this->buildDependencyInjectedAnswer($command);
             } else {
                 $command = new $command();
@@ -220,11 +220,11 @@ class CommandBus extends AnswerBus
     protected function execute($name, $arguments, $message)
     {
         if (array_key_exists($name, $this->commands)) {
-            return $this->commands[$name]->make($this->telegram, $arguments, $message);
+            return $this->commands[$name]->make($this->getBot(), $arguments, $message);
         } elseif (array_key_exists($name, $this->commandAliases)) {
-            return $this->commandAliases[$name]->make($this->telegram, $arguments, $message);
+            return $this->commandAliases[$name]->make($this->getBot(), $arguments, $message);
         } elseif (array_key_exists('help', $this->commands)) {
-            return $this->commands['help']->make($this->telegram, $arguments, $message);
+            return $this->commands['help']->make($this->getBot(), $arguments, $message);
         }
 
         return 'Ok';

--- a/src/Commands/CommandBus.php
+++ b/src/Commands/CommandBus.php
@@ -88,8 +88,7 @@ class CommandBus extends AnswerBus
             }
         }
 
-        if ($command instanceof CommandInterface)
-        {
+        if ($command instanceof CommandInterface) {
             /*
              * At this stage we definitely have a proper command to use.
              *

--- a/src/Commands/CommandInterface.php
+++ b/src/Commands/CommandInterface.php
@@ -3,7 +3,7 @@
 namespace Telegram\Bot\Commands;
 
 use Telegram\Bot\Objects\Update;
-use Telegram\Bot\Bots\Bot;
+use Telegram\Bot\Commands\CommandBot;
 
 /**
  * Interface CommandInterface.
@@ -41,11 +41,11 @@ interface CommandInterface
     /**
      * Process Inbound Command.
      *
-     * @param Bot $bot
+     * @param CommandBot $bot
      * @param string $arguments
      * @param Update $update
      *
      * @return mixed
      */
-    public function make(Bot $bot, $arguments, Update $update);
+    public function make(CommandBot $bot, $arguments, Update $update);
 }

--- a/src/Commands/CommandInterface.php
+++ b/src/Commands/CommandInterface.php
@@ -2,8 +2,8 @@
 
 namespace Telegram\Bot\Commands;
 
-use Telegram\Bot\Api;
 use Telegram\Bot\Objects\Update;
+use Telegram\Bot\Bots\Bot;
 
 /**
  * Interface CommandInterface.
@@ -41,11 +41,11 @@ interface CommandInterface
     /**
      * Process Inbound Command.
      *
-     * @param Api $telegram
+     * @param Bot $bot
      * @param string $arguments
      * @param Update $update
      *
      * @return mixed
      */
-    public function make(Api $telegram, $arguments, Update $update);
+    public function make(Bot $bot, $arguments, Update $update);
 }

--- a/src/Commands/HelpCommand.php
+++ b/src/Commands/HelpCommand.php
@@ -27,7 +27,7 @@ class HelpCommand extends Command
      */
     public function handle($arguments)
     {
-        $commands = $this->telegram->getCommands();
+        $commands = $this->getBot()->getCommands();
 
         $text = '';
         foreach ($commands as $name => $handler) {

--- a/src/Events/UpdateWasReceived.php
+++ b/src/Events/UpdateWasReceived.php
@@ -4,6 +4,7 @@ namespace Telegram\Bot\Events;
 
 use League\Event\AbstractEvent;
 use Telegram\Bot\Api;
+use Telegram\Bot\Bots\Bot;
 use Telegram\Bot\Objects\Update;
 
 class UpdateWasReceived extends AbstractEvent
@@ -14,9 +15,9 @@ class UpdateWasReceived extends AbstractEvent
     private $update;
 
     /**
-     * @var Api
+     * @var Bot
      */
-    private $telegram;
+    private $bot;
 
     /**
      * UpdateWasReceived constructor.
@@ -24,10 +25,10 @@ class UpdateWasReceived extends AbstractEvent
      * @param Update $update
      * @param Api    $telegram
      */
-    public function __construct(Update $update, Api $telegram)
+    public function __construct(Update $update, Bot $bot)
     {
         $this->update = $update;
-        $this->telegram = $telegram;
+        $this->bot = $bot;
     }
 
     /**
@@ -43,6 +44,14 @@ class UpdateWasReceived extends AbstractEvent
      */
     public function getTelegram()
     {
-        return $this->telegram;
+        return $this->bot->getApi();
+    }
+    
+    /**
+     * @return Bot
+     */
+    public function getBot()
+    {
+        return $this->bot;
     }
 }

--- a/src/Laravel/TelegramServiceProvider.php
+++ b/src/Laravel/TelegramServiceProvider.php
@@ -3,7 +3,7 @@
 namespace Telegram\Bot\Laravel;
 
 use Telegram\Bot\Api;
-use Telegram\Bot\BotsManager;
+use Telegram\Bot\Bots\BotsManager;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Contracts\Container\Container as Application;
 use Laravel\Lumen\Application as LumenApplication;

--- a/src/Laravel/TelegramServiceProvider.php
+++ b/src/Laravel/TelegramServiceProvider.php
@@ -2,7 +2,7 @@
 
 namespace Telegram\Bot\Laravel;
 
-use Telegram\Bot\Api;
+use Telegram\Bot\Bots\Bot;
 use Telegram\Bot\Bots\BotsManager;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Contracts\Container\Container as Application;
@@ -95,7 +95,7 @@ class TelegramServiceProvider extends ServiceProvider
             return $manager->bot();
         });
 
-        $app->alias('telegram.bot', Api::class);
+        $app->alias('telegram.bot', Bot::class);
     }
 
     /**
@@ -105,6 +105,6 @@ class TelegramServiceProvider extends ServiceProvider
      */
     public function provides()
     {
-        return ['telegram', 'telegram.bot', BotsManager::class, Api::class];
+        return ['telegram', 'telegram.bot', BotsManager::class, Bot::class];
     }
 }

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -72,12 +72,6 @@ class ApiTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
-    public function it_checks_the_commandBus_is_returned()
-    {
-        $this->assertInstanceOf(CommandBus::class, $this->api->getCommandBus());
-    }
-
-    /** @test */
     public function it_checks_an_ioc_container_can_be_set()
     {
         $this->api->setContainer(Mocker::createContainer()->reveal());
@@ -86,35 +80,15 @@ class ApiTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
-    public function it_checks_an_update_object_is_returned_when_a_command_is_handled()
-    {
-        $this->api = Mocker::createMessageResponse('/start');
-        $updates = $this->api->commandsHandler();
-        $this->assertInstanceOf(Update::class, $updates[0]);
-    }
-
-    /** @test */
-    public function it_checks_the_correct_command_is_handled()
-    {
-        $this->api = Mocker::createMessageResponse('/mycommand');
-        $command = Mocker::createMockCommand('mycommand');
-        $command2 = Mocker::createMockCommand('mycommand2');
-
-        $this->api->addCommands([$command->reveal(), $command2->reveal()]);
-
-        $this->api->commandsHandler();
-
-        $command->make(Argument::any(), Argument::any(), Argument::any())->shouldHaveBeenCalled();
-        $command2->make(Argument::any(), Argument::any(), Argument::any())->shouldNotHaveBeenCalled();
-    }
-
-    /** @test */
     public function it_checks_the_lastResponse_property_gets_populated_after_a_request()
     {
+        $this->api = Mocker::createMockedEndpoint();
+        
         $this->assertEmpty($this->api->getLastResponse());
 
-        $this->api = Mocker::createMessageResponse('/start');
-        $this->api->commandsHandler();
+        //$this->api = Mocker::createMessageResponse('/start');
+        $this->api->getMe();
+        //$this->api->commandsHandler();
 
         $lastResponse = $this->api->getLastResponse();
         $this->assertNotEmpty($lastResponse);

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -3,7 +3,6 @@
 namespace Telegram\Bot\Tests;
 
 use Telegram\Bot\Api;
-use Prophecy\Argument;
 use InvalidArgumentException;
 use Telegram\Bot\Objects\File;
 use Telegram\Bot\Objects\User;

--- a/tests/BotTest.php
+++ b/tests/BotTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Telegram\Bot\Tests;
+
+use PHPUnit_Framework_TestCase;
+use Telegram\Bot\Bots\Bot;
+use Telegram\Bot\Tests\Mocks\Mocker;
+use Telegram\Bot\Events\UpdateWasReceived;
+
+class BotTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Bot
+     */
+    protected $bot;
+
+    public function setUp()
+    {
+        $this->bot = new Bot('testbot', Mocker::createApi()->reveal());
+    }
+
+    /** @test */
+    public function it_checks_the_name_can_be_set()
+    {
+        $this->assertEquals('testbot', $this->bot->getName());
+        $this->bot->setName('another');
+        $this->assertEquals('another', $this->bot->getName());
+    }
+    
+    /** @test */
+    public function it_emits_update_events()
+    {
+        $emittedEvent = null;
+        $this->bot->addUpdateListener(function ($event) use (&$emittedEvent) {
+            $emittedEvent = $event;
+        });
+        $this->bot->processUpdates([Mocker::createUpdateObject()->reveal()]);
+        
+        $this->assertInstanceOf(UpdateWasReceived::class, $emittedEvent);
+        
+    }
+}

--- a/tests/BotTest.php
+++ b/tests/BotTest.php
@@ -4,8 +4,9 @@ namespace Telegram\Bot\Tests;
 
 use PHPUnit_Framework_TestCase;
 use Telegram\Bot\Bots\Bot;
-use Telegram\Bot\Tests\Mocks\Mocker;
 use Telegram\Bot\Events\UpdateWasReceived;
+use Telegram\Bot\Objects\Update;
+use Telegram\Bot\Tests\Mocks\Mocker;
 
 class BotTest extends PHPUnit_Framework_TestCase
 {
@@ -34,9 +35,17 @@ class BotTest extends PHPUnit_Framework_TestCase
         $this->bot->addUpdateListener(function ($event) use (&$emittedEvent) {
             $emittedEvent = $event;
         });
-        $this->bot->processUpdates([Mocker::createUpdateObject()->reveal()]);
+        $this->bot->processUpdate(Mocker::createUpdateObject()->reveal());
         
         $this->assertInstanceOf(UpdateWasReceived::class, $emittedEvent);
         
+    }
+    
+    /** @test */
+    public function it_checks_an_update_object_is_returned_when_an_update_is_handled()
+    {
+        $this->bot = new Bot('testbot', Mocker::createMessageResponse('/start'));        
+        $updates = $this->bot->checkForUpdates();
+        $this->assertInstanceOf(Update::class, $updates[0]);
     }
 }

--- a/tests/BotsManagerTest.php
+++ b/tests/BotsManagerTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Telegram\Bot\Tests;
+
+use PHPUnit_Framework_TestCase;
+use Telegram\Bot\Bots\Bot;
+use Telegram\Bot\Bots\BotsManager;
+use Telegram\Bot\Commands\CommandBot;
+
+
+class BotsManagerTest extends PHPUnit_Framework_TestCase
+{
+    
+    var $testConfig = [    
+        'default' => 'defaultbot',
+
+        'bots' => [
+            'defaultbot' => [
+                'username'  => 'defaultbotname',
+                'token' => '12345',
+                'commands' => [],
+                'use_emojify' => true,
+            ],
+        ],
+
+        'async_requests' => false,
+
+        'http_client_handler' => null,
+
+        'resolve_command_dependencies' => true,
+
+        'commands' => [
+            \Telegram\Bot\Commands\HelpCommand::class,
+        ],
+
+        'command_groups' => [],
+
+        'shared_commands' => [],
+    ];
+    
+    /**
+     * @var BotsManager
+     */
+    protected $manager;
+
+    public function setUp()
+    {
+        $this->manager = new BotsManager($this->testConfig);
+    }
+
+    /** @test */
+    public function it_checks_the_config_gets_read()
+    {
+        $config = $this->testConfig['bots'][$this->testConfig['default']];
+        $config['bot'] = $this->testConfig['default'];
+        
+        $this->assertEquals(
+            $config,
+            $this->manager->getBotConfig()
+        );        
+    }
+    
+    /** @test */
+    public function it_checks_the_bot_instance_gets_created_and_stored(){
+        $bot1 = $this->manager->bot();
+        $this->assertInstanceOf(Bot::class, $bot1);
+        
+        $bot2 = $this->manager->bot();
+        $this->assertEquals($bot2, $bot1);        
+    }
+    
+    /** @test */
+    public function it_checks_the_command_gets_added(){
+        $bot = $this->manager->bot();
+        $this->assertInstanceOf(CommandBot::class, $bot);
+        
+        $command = $bot->getCommands()['help'];
+        $this->assertInstanceOf(\Telegram\Bot\Commands\HelpCommand::class, $command);
+        
+    }
+    
+}

--- a/tests/CommandBotTest.php
+++ b/tests/CommandBotTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Telegram\Bot\Tests;
+
+use PHPUnit_Framework_TestCase;
+use Telegram\Commands\CommandBot;
+use Telegram\CommandBus;
+use Telegram\Bot\Tests\Mocks\Mocker;
+
+class CommandBotTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Bot
+     */
+    protected $bot;
+
+    public function setUp()
+    {
+        $this->bot = new CommandBot('testbot', Mocker::createApi()->reveal());
+    }
+
+    /** @test */
+    public function it_checks_the_commandBus_is_returned()
+    {
+        $this->assertInstanceOf(CommandBus::class, $this->bot->getCommandBus());
+    }
+    
+    /** @test */
+    public function it_checks_the_correct_command_is_handled()
+    {
+        $this->api = Mocker::createMessageResponse('/mycommand');
+        $command = Mocker::createMockCommand('mycommand');
+        $command2 = Mocker::createMockCommand('mycommand2');
+
+        $this->api->addCommands([$command->reveal(), $command2->reveal()]);
+
+        $this->api->commandsHandler();
+
+        $command->make(Argument::any(), Argument::any(), Argument::any())->shouldHaveBeenCalled();
+        $command2->make(Argument::any(), Argument::any(), Argument::any())->shouldNotHaveBeenCalled();
+    }
+}

--- a/tests/CommandBotTest.php
+++ b/tests/CommandBotTest.php
@@ -3,9 +3,10 @@
 namespace Telegram\Bot\Tests;
 
 use PHPUnit_Framework_TestCase;
-use Telegram\Commands\CommandBot;
-use Telegram\CommandBus;
+use Telegram\Bot\Commands\CommandBot;
+use Telegram\Bot\Commands\CommandBus;
 use Telegram\Bot\Tests\Mocks\Mocker;
+use Prophecy\Argument;
 
 class CommandBotTest extends PHPUnit_Framework_TestCase
 {
@@ -32,9 +33,9 @@ class CommandBotTest extends PHPUnit_Framework_TestCase
         $command = Mocker::createMockCommand('mycommand');
         $command2 = Mocker::createMockCommand('mycommand2');
 
-        $this->api->addCommands([$command->reveal(), $command2->reveal()]);
-
-        $this->api->commandsHandler();
+        $bot = new CommandBot('apibot', $this->api);
+        $bot->addCommands([$command->reveal(), $command2->reveal()]);
+        $bot->checkForUpdates();
 
         $command->make(Argument::any(), Argument::any(), Argument::any())->shouldHaveBeenCalled();
         $command2->make(Argument::any(), Argument::any(), Argument::any())->shouldNotHaveBeenCalled();

--- a/tests/CommandBusTest.php
+++ b/tests/CommandBusTest.php
@@ -19,7 +19,7 @@ class CommandBusTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->commandBus = new CommandBus(Mocker::createApi()->reveal());
+        $this->commandBus = new CommandBus(Mocker::createBot()->reveal());
     }
 
     /** @test */
@@ -148,8 +148,8 @@ class CommandBusTest extends \PHPUnit_Framework_TestCase
     /** @test */
     public function it_checks_a_commands_dependencies_will_be_resolved_if_an_ioc_container_has_been_set()
     {
-        //Make an API with an IOC container
-        $this->commandBus = new CommandBus(Mocker::createApi(true)->reveal());
+        //Make an bot with an IOC container
+        $this->commandBus = new CommandBus(Mocker::createBot(true)->reveal());
         $this->commandBus->addCommand('\Telegram\Bot\Tests\Mocks\MockCommandWithDependency');
         $allCommands = $this->commandBus->getCommands();
 

--- a/tests/Mocks/Mocker.php
+++ b/tests/Mocks/Mocker.php
@@ -11,6 +11,7 @@ use GuzzleHttp\Psr7\Response;
 use Telegram\Bot\Objects\Update;
 use GuzzleHttp\Handler\MockHandler;
 use Telegram\Bot\HttpClients\GuzzleHttpClient;
+use Telegram\Bot\Commands\CommandBot;
 
 class Mocker
 {
@@ -36,6 +37,19 @@ class Mocker
         $api->getContainer()->willReturn($container);
 
         return $api;
+    }
+    
+    /**
+     * Create a mocked bot
+     *
+     * @return \Prophecy\Prophecy\ObjectProphecy
+     */
+    public static function createBot($withContainer = false)
+    {
+        $bot = (new Prophet())->prophesize(CommandBot::class);
+        $bot->getApi()->willReturn(Mocker::createApi($withContainer));        
+        
+        return $bot;
     }
 
     /**

--- a/tests/Mocks/Mocker.php
+++ b/tests/Mocks/Mocker.php
@@ -173,4 +173,11 @@ class Mocker
 
         return new Api('token', false, $client);
     }
+    
+    /**
+     * Creates an Api object with mock http clinet
+     */
+    static function createMockedEndpoint(){
+        return self::setTelegramResponse("");
+    }
 }


### PR DESCRIPTION
I believe we should seperate the concerns of the Api class, which have nothing to do with a barebones telegram Api.
Like handling commands, emitting events, building conversations, etc.
For these things i created a separate Bot class.

Things still needed to be done before merging:

- [ ]  Understand, implement and test the container/DI stuff
- [X] Document the Bot class

- [ ] Write a usage example of `Bot`, `checkForUpdates` and `Events`.
Is there an official Event tutorial? (I know the one in the pull request, but thats not official documentation) How to update the docs? What is the status of the upgrade guide?

- [X] Fix current tests

- [x] Try to write some tests. (As i mainly moved some untested stuff from one place to another, there is not much to copy/modify) I am open for test suggestions ;-)

Things to discuss (and tackle maybe afterwards)

- [ ] Is all the magic `__call` stuff helpful or confusing. Yes, it may be convenient to call everything everywhere, but it also introduces bugs (the `getXXX` in Api) and adds complexity.

- [ ] The variable holding the telegram api object is not consistently named. Sometimes `$telegram`, sometimes `$api`. It gets a bit better with the distinction of `$bot`, but imho it should always be `$api`, never `$telegram`.

- [ ] The config system is a bit too intricate. I get what you are trying to do with reusable config blocks like the shared commands and such, but with the addition of e.g. the event and conversation system we might find a seamless config mechanism for all of that.
