### PR TITLE
Implemented recent Telegram API updates.

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -9,6 +9,8 @@ use Telegram\Bot\Events\UpdateWasReceived;
 use Telegram\Bot\Exceptions\TelegramSDKException;
 use Telegram\Bot\FileUpload\InputFile;
 use Telegram\Bot\HttpClients\HttpClientInterface;
+use Telegram\Bot\Objects\Chat;
+use Telegram\Bot\Objects\ChatMember;
 use Telegram\Bot\Objects\File;
 use Telegram\Bot\Objects\Message;
 use Telegram\Bot\Objects\UnknownObject;
@@ -780,6 +782,73 @@ class Api
     public function answerCallbackQuery(array $params)
     {
         return $this->post('answerCallbackQuery', $params);
+    }
+
+    /**
+     * Get up to date information about the chat (current name of the user for one-on-one conversations,
+     * current username of a user, group or channel,
+     *
+     * <code>
+     * $params = [
+     *   'chat_id'  => '',
+     * ];
+     * </code>
+     *
+     * @link https://core.telegram.org/bots/api#getchat
+     *
+     * @param array $params
+     *
+     * @var string|int  $params ['chat_id'] Unique identifier for the target chat or username of the target supergroup or channel (in the format @channelusername)
+     *
+     * @return Chat
+     */
+    public function getChat(array $params)
+    {
+        return $this->post('getChat', $params);
+    }
+
+    /**
+     * Get a list of administrators in a chat.
+     *
+     * <code>
+     * $params = [
+     *   'chat_id'  => '',
+     * ];
+     * </code>
+     *
+     * @link https://core.telegram.org/bots/api#getchatadministrators
+     *
+     * @param array $params
+     *
+     * @var string|int  $params ['chat_id'] Unique identifier for the target chat or username of the target supergroup or channel (in the format @channelusername);
+     *
+     * @return ChatMember[]
+     */
+    public function getChatAdministrators(array $params)
+    {
+        return $this->post('getChatAdministrators', $params);
+    }
+
+    /**
+     * Get the number of members in a chat
+     *
+     * <code>
+     * $params = [
+     *   'chat_id'  => '',
+     * ];
+     * </code>
+     *
+     * @link https://core.telegram.org/bots/api#getchatmemberscount
+     *
+     * @param array $params
+     *
+     * @var string|int  $params ['chat_id'] Unique identifier for the target chat or username of the target supergroup or channel (in the format @channelusername)
+     *
+     * @return int
+     */
+    public function getChatMembersCount(array $params)
+    {
+        return $this->post('getChatMembersCount', $params);
     }
 
     /**

--- a/src/Objects/ChatMember.php
+++ b/src/Objects/ChatMember.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Telegram\Bot\Objects;
+
+/**
+ * Class ChatMember.
+ *
+ * @method User            getUser()             Information about the user.
+ * @method string          getStatus()           (Optional). The member's status in the chat. Can be “creator”, “administrator”, “member”, “left” or “kicked”
+ */
+class ChatMember extends BaseObject
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function relations()
+    {
+        return [
+            'user'    => User::class,
+        ];
+    }
+}

--- a/src/Objects/EditedMessage.php
+++ b/src/Objects/EditedMessage.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Telegram\Bot\Objects;
+
+/**
+ * {@inheritdoc}
+ */
+class EditedMessage extends Message
+{
+}

--- a/src/Objects/Message.php
+++ b/src/Objects/Message.php
@@ -13,6 +13,7 @@ namespace Telegram\Bot\Objects;
  * @method User             getForwardFrom()            (Optional). For forwarded messages, sender of the original message.
  * @method int              getForwardDate()            (Optional). For forwarded messages, date the original message was sent in Unix time.
  * @method Message          getReplyToMessage()         (Optional). For replies, the original message. Note that the Message object in this field will not contain further reply_to_message fields even if it itself is a reply.
+ * @method int              getEditDate()               (Optional). Date the message was last edited in Unix time.
  * @method MessageEntity[]  getEntities()               (Optional). For text messages, special entities like usernames, URLs, bot commands, etc. that appear in the text.
  * @method Audio            getAudio()                  (Optional). Message is an audio file, information about the file.
  * @method Document         getDocument()               (Optional). Message is a general file, information about the file.
@@ -46,6 +47,7 @@ class Message extends BaseObject
             'from'             => User::class,
             'chat'             => Chat::class,
             'forward_from'     => User::class,
+            'forward_from_chat'=> User::class,
             'reply_to_message' => self::class,
             'entities'         => MessageEntity::class,
             'audio'            => Audio::class,

--- a/src/Objects/MessageEntity.php
+++ b/src/Objects/MessageEntity.php
@@ -6,10 +6,11 @@ namespace Telegram\Bot\Objects;
  * Class Location.
  *
  *
- * @method string   getType()   Type of the entity. One of mention (@username), hashtag, bot_command, url, email, bold (bold text), italic (italic text), code (monowidth string), pre (monowidth block), text_link (for clickable text URLs)
+ * @method string   getType()   Type of the entity. Can be mention (@username), hashtag, bot_command, url, email, bold (bold text), italic (italic text), code (monowidth string), pre (monowidth block), text_link (for clickable text URLs), text_mention (for users without usernames).
  * @method int      getOffset() Offset in UTF-16 code units to the start of the entity
  * @method int      getLength() Length of the entity in UTF-16 code units
  * @method string   getUrl()    (Optional). For "text_link" only, url that will be opened after user taps on the text.
+ * @method User     getUser()   (Optional). For “text_mention” only, the mentioned user.
  */
 class MessageEntity extends BaseObject
 {

--- a/src/Objects/Sticker.php
+++ b/src/Objects/Sticker.php
@@ -10,6 +10,7 @@ namespace Telegram\Bot\Objects;
  * @method int          getWidth()      Sticker width.
  * @method int          getHeight()     Sticker height.
  * @method PhotoSize    getThumb()      (Optional). Sticker thumbnail in .webp or .jpg format.
+ * @method string       getEmoji()      (Optional). Emoji associated with the sticker
  * @method int          getFileSize()   (Optional). File size.
  */
 class Sticker extends BaseObject

--- a/src/Objects/Update.php
+++ b/src/Objects/Update.php
@@ -8,6 +8,7 @@ namespace Telegram\Bot\Objects;
  *
  * @method int                  getUpdateId()               The update's unique identifier. Update identifiers start from a certain positive number and increase sequentially.
  * @method Message              getMessage()                (Optional). New incoming message of any kind - text, photo, sticker, etc.
+ * @method EditedMessage        getEditedMessage()          (Optional). New version of a message that is known to the bot and was edited.
  * @method InlineQuery          getInlineQuery()            (Optional). New incoming inline query.
  * @method ChosenInlineResult   getChosenInlineResult()     (Optional). A result of an inline query that was chosen by the user and sent to their chat partner.
  * @method CallbackQuery        getCallbackQuery()          (Optional). Incoming callback query.
@@ -23,6 +24,7 @@ class Update extends BaseObject
     {
         return [
             'message'              => Message::class,
+            'edited_message'       => EditedMessage::class,
             'inline_query'         => InlineQuery::class,
             'chosen_inline_result' => ChosenInlineResult::class,
             'callback_query'       => CallbackQuery::class,
@@ -64,6 +66,7 @@ class Update extends BaseObject
     {
         $types = [
             'message',
+            'edited_message',
             'inline_query',
             'chosen_inline_result',
             'callback_query',


### PR DESCRIPTION
Implemented recent Telegram API updates.

May 22, 2016

Bot API 2.1. Added more tools for group administrator bots. Your bot can now get a list of administrators and members count in a group, check a user's current status (administrator, creator, left the group, kicked from the group), and leave a group.
Added new methods: getChat, leaveChat, getChatAdministrators, getChatMember, getChatMembersCount.
Added support for edited messages and new mentions from Telegram v.3.9. New fields: edited_message in Update, edit_date in Message, user in MessageEntity. New value text_mention for the type field in MessageEntity.

May 6, 2016

Added the field emoji to the Sticker object. Your bot can now know the emoji a sticker corresponds to.
Added the field forward_from_chat to the Message object for messages forwarded from channels.