### PR TITLE
update composer for new laravel (illuminate/support 5.3)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.5
   - 5.6
   - 7.0
   - hhvm

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   "require": {
     "php": ">=5.5.0",
     "guzzlehttp/guzzle": "~6.0",
-    "illuminate/support": "~5.0",
+    "illuminate/support": "~5.3",
     "league/event": "^2.1"
   },
   "require-dev": {


### PR DESCRIPTION
Hi,

Update illuminate support to latest version in order to be compatible with Laravel 5.3. As you can see I removed php 5.5 tests from travis. PHP 5.5 is already outdated and it's time to drop supporting this version.

http://php.net/supported-versions.php

Regards,