### PR TITLE
Drop PHP 5.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.5
   - 5.6
   - 7.0
   - hhvm


### PR DESCRIPTION
Hi..

As you can see PHP 5.5 is already outdated and it's time to drop supporting this version.

http://php.net/supported-versions.php

Regards,