### PR TITLE
Improve Update->getMessage()

### DIFF
--- a/src/Objects/Update.php
+++ b/src/Objects/Update.php
@@ -82,32 +82,34 @@ class Update extends BaseObject
     }
 
     /**
-     * Returns message.
+     * Get the message contained in the Update
      *
      * @return null|EditedMessage|Message
      */
     public function getMessage()
     {
-        if ($this->has('message')) {
-            return $this->message;
-        } elseif ($this->has('edited_message')) {
-            return $this->editedMessage;
+        switch ($this->detectType()) {
+            case 'message':
+                return $this->message;
+            case 'edited_message':
+                return $this->editedMessage;
+            case 'callback_query':
+                $callbackQuery = $this->callbackQuery;
+                if ($callbackQuery->has('message')) {
+                    return $callbackQuery->message;
+                }
+                break;
         }
-
         return null;
     }
 
     /**
-     * Get message object (if exists)
+     * Get chat object (if exists)
      *
      * @return null|Chat
      */
     public function getChat()
     {
-        if ($this->isType('callback_query')) {
-            return $this->callbackQuery->message->chat;
-        }
-
         if (null === $message = $this->getMessage()) {
             return null;
         }


### PR DESCRIPTION
It does make more sense if `Update->getMessage()` returns any contained message.

Alternatively we could refactor it to `getIncludedMessage()`, as now $update->getMessage() and $update->message could return differently.
