### PR TITLE
Apply new BOT API 2.3.1 features. December 4, 2016

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -23,6 +23,7 @@ use Telegram\Bot\Traits\Http;
  *         polling.
  * @method Methods\SetWebhook setWebhook(array $params = []) Set a Webhook to receive incoming updates via an outgoing
  *         webhook.
+ * @method Methods\DeleteWebhook deleteWebhook(array $params = []) Remove webhook integration.
  * @method Methods\GetWebhookInfo getWebhookInfo() Use this method to get current webhook status.
  *
  * # Available Methods

--- a/src/Keyboard/Keyboard.php
+++ b/src/Keyboard/Keyboard.php
@@ -166,7 +166,7 @@ class Keyboard extends Base
      */
     public static function hide(array $params = [])
     {
-        return new static(array_merge(['hide_keyboard' => true, 'selective' => false], $params));
+        return new static(array_merge(['remove_keyboard' => true, 'selective' => false], $params));
     }
 
     /**

--- a/src/Methods/AnswerCallbackQuery.php
+++ b/src/Methods/AnswerCallbackQuery.php
@@ -14,6 +14,7 @@ namespace Telegram\Bot\Methods;
  *   'text'               => '',
  *   'show_alert'         => '',
  *   'url'                => '',
+ *   'cache_time'         => '',
  * ];
  * </code>
  *
@@ -23,6 +24,7 @@ namespace Telegram\Bot\Methods;
  * @method AnswerCallbackQuery text($text) string
  * @method AnswerCallbackQuery showAlert($showAlert) bool
  * @method AnswerCallbackQuery url($url) string
+ * @method AnswerCallbackQuery cacheTime($cacheTime) int
  *
  * @method bool getResult($dumpAndDie = false)
  */

--- a/src/Methods/DeleteWebhook.php
+++ b/src/Methods/DeleteWebhook.php
@@ -1,0 +1,28 @@
+<?php
+namespace Telegram\Bot\Methods;
+
+use Telegram\Bot\Exceptions\TelegramSDKException;
+
+/**
+ * Class DeleteWebhook
+ *
+ * Remove webhook integration.
+ *
+ * @link https://core.telegram.org/bots/api#deletewebhook
+ *
+ * @method bool getResult($dumpAndDie = false)
+ */
+class DeleteWebhook extends Method
+{
+    /** {@inheritdoc} */
+    protected $getRequest = true;
+
+    /** {@inheritdoc} */
+    protected $noParams = true;
+
+    /** {@inheritdoc} */
+    protected function returns()
+    {
+        return $this->factory->response();
+    }
+}

--- a/src/Methods/GetUpdates.php
+++ b/src/Methods/GetUpdates.php
@@ -11,9 +11,10 @@ use Telegram\Bot\Events\UpdateWasReceived;
  *
  * <code>
  * $params = [
- *   'offset'  => '',
- *   'limit'   => '',
- *   'timeout' => '',
+ *   'offset'          => '',
+ *   'limit'           => '',
+ *   'timeout'         => '',
+ *   'allowed_updates' => [],
  * ];
  * </code>
  *
@@ -22,6 +23,7 @@ use Telegram\Bot\Events\UpdateWasReceived;
  * @method GetUpdates offset($offset = null) int|null
  * @method GetUpdates limit($limit = null) int|null
  * @method GetUpdates timeout($timeout = null) int|null
+ * @method GetUpdates allowedUpdates($allowedUpdates = null) array|null
  *
  * @method Update[] getResult($dumpAndDie = false)
  */

--- a/src/Methods/SetGameScore.php
+++ b/src/Methods/SetGameScore.php
@@ -12,12 +12,13 @@ use Telegram\Bot\Objects\Message;
  *
  * <code>
  * $params = [
- *   'user_id'           => '',
- *   'score'             => '',
- *   'chat_id'           => '',
- *   'message_id'        => '',
- *   'inline_message_id' => '',
- *   'edit_message'      => '',
+ *   'user_id'              => '',
+ *   'score'                => '',
+ *   'force'                => '',
+ *   'disable_edit_message' => '',
+ *   'chat_id'              => '',
+ *   'message_id'           => '',
+ *   'inline_message_id'    => '',
  * ];
  * </code>
  *
@@ -25,10 +26,11 @@ use Telegram\Bot\Objects\Message;
  *
  * @method SetGameScore userId($userId) int
  * @method SetGameScore score($score) int
+ * @method SetGameScore force($force) bool
+ * @method SetGameScore disableEditMessage($disableEditMessage) bool
  * @method SetGameScore chatId($chatId) int|string
  * @method SetGameScore messageId($messageId) int
  * @method SetGameScore inlineMessageId($inlineMessageId) string
- * @method SetGameScore editMessage($editMessage) bool
  *
  * @method Message getResult($dumpAndDie = false)
  */

--- a/src/Methods/SetWebhook.php
+++ b/src/Methods/SetWebhook.php
@@ -11,16 +11,25 @@ use Telegram\Bot\FileUpload\InputFile;
  *
  * <code>
  * $params = [
- *   'url'         => '',
- *   'certificate' => '',
+ *   'url'             => '',
+ *   'certificate'     => '',
+ *   'max_connections' => '',
+ *   'allowed_updates' => [],
  * ];
  * </code>
  *
  * @link https://core.telegram.org/bots/api#setwebhook
  *
- * @method SetWebhook url($url) string HTTPS url to send updates to.
- * @method SetWebhook certificate(InputFile $certificate) InputFile Upload your public key certificate so that the root
- *         certificate in use can be checked.
+ * @method SetWebhook url($url) string                      HTTPS url to send updates to.
+ * @method SetWebhook certificate(InputFile $certificate)   InputFile Upload your public key certificate so that the root
+ *                                                          certificate in use can be checked.
+ * @method SetWebhook maxConnections($maxConnections) int   Maximum allowed number of simultaneous HTTPS connections to the webhook for update
+ *                                                          delivery, 1-100. Defaults to 40. Use lower values to limit the load on your bot‘s server,
+ *                                                          and higher values to increase your bot’s throughput.
+ * @method SetWebhook allowedUpdates($allowedUpdates) array List the types of updates you want your bot to receive. For example, specify [“message”,
+ *                                                          “edited_channel_post”, “callback_query”] to only receive updates of these types.
+ *                                                          Specify an empty list to receive all updates regardless of type (default).
+ *                                                          If not specified, the previous setting will be used.
  *
  * @method bool getResult($dumpAndDie = false)
  */
@@ -42,6 +51,8 @@ class SetWebhook extends Method
 
         if (!isset($this->payload['certificate']) || !is_readable($this->payload['certificate'])) {
             $this->payload['certificate'] = null;
+            //TODO @irazasyed - We need to chat about the following line. :-)
+            $this->fileUploadField = null;
         }
     }
 

--- a/src/Objects/Message.php
+++ b/src/Objects/Message.php
@@ -10,6 +10,8 @@ namespace Telegram\Bot\Objects;
  * @property int              $date                   Date the message was sent in Unix time.
  * @property Chat             $chat                   Conversation the message belongs to.
  * @property User             $forwardFrom            (Optional). For forwarded messages, sender of the original message.
+ * @property Chat             $forwardFromChat        (Optional). For messages forwarded from a channel, information about the original channel.
+ * @property int              forwardFromMessageId    (Optional). For forwarded channel posts, identifier of the original message in the channel.
  * @property int              $forwardDate            (Optional). For forwarded messages, date the original message was sent in Unix time.
  * @property Message          $replyToMessage         (Optional). For replies, the original message. Note that the Message object in this field will not contain further reply_to_message fields even if it itself is a reply.
  * @property int              $editDate               (Optional). Date the message was last edited in Unix time.
@@ -22,6 +24,7 @@ namespace Telegram\Bot\Objects;
  * @property Sticker          $sticker                (Optional). Message is a sticker, information about the sticker.
  * @property Video            $video                  (Optional). Message is a video, information about the video.
  * @property Voice            $voice                  (Optional). Message is a voice message, information about the file.
+ * @property string           $caption                (Optional). Caption for the document, photo or video, 0-200 characters.
  * @property Contact          $contact                (Optional). Message is a shared contact, information about the contact.
  * @property Location         $location               (Optional). Message is a shared location, information about the location.
  * @property Venue            $venue                  (Optional). Message is a venue, information about the venue.
@@ -48,7 +51,7 @@ class Message extends BaseObject
             'from'             => User::class,
             'chat'             => Chat::class,
             'forward_from'     => User::class,
-            'forward_from_chat'=> User::class,
+            'forward_from_chat'=> Chat::class,
             'reply_to_message' => self::class,
             'entities'         => MessageEntity::class,
             'audio'            => Audio::class,

--- a/src/Objects/Update.php
+++ b/src/Objects/Update.php
@@ -12,6 +12,10 @@ namespace Telegram\Bot\Objects;
  *                                                      sticker, etc.
  * @property EditedMessage      $editedMessage          (Optional). New version of a message that is known to the bot
  *                                                      and was edited.
+ * @property Message            $channelPost            (Optional).Optional. New incoming channel post of any kind — text,
+ *                                                      photo, sticker, etc.
+ * @property EditedMessage      $editedChannelPost      (Optional). New version of a channel post that is known to the
+ *                                                      bot and was edited sticker, etc.
  * @property InlineQuery        $inlineQuery            (Optional). New incoming inline query.
  * @property ChosenInlineResult $chosenInlineResult     (Optional). A result of an inline query that was chosen by the
  *                                                      user and sent to their chat partner.
@@ -29,6 +33,8 @@ class Update extends BaseObject
         return [
             'message'              => Message::class,
             'edited_message'       => EditedMessage::class,
+            'channel_post'         => Message::class,
+            'edited_channel_post'  => EditedMessage::class,
             'inline_query'         => InlineQuery::class,
             'chosen_inline_result' => ChosenInlineResult::class,
             'callback_query'       => CallbackQuery::class,
@@ -71,6 +77,8 @@ class Update extends BaseObject
         $types = [
             'message',
             'edited_message',
+            'channel_post',
+            'edited_channel_post',
             'inline_query',
             'chosen_inline_result',
             'callback_query',


### PR DESCRIPTION
Apply new BOT API 2.3.1 features.
December 4, 2016

Introducing Bot API 2.3.1, a nifty little update that will give you more control over how your bot gets its updates.
Use the new field max_connections in setWebhook to optimize your bot's server load
Use allowed_updates in setWebhook and getUpdates to selectively subscribe to updates of a certain type. Among other things, this allows you to stop getting updates about new posts in channels where your bot is an admin.
deleteWebhook moved out of setWebhook to get a whole separate method for itself.