### PR TITLE
pass through params from commandsHandler() to getUpdates()

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -1309,11 +1309,12 @@ class Api
     /**
      * Processes Inbound Commands.
      *
-     * @param bool $webhook
+     * @param bool  $webhook
+     * @param array $params
      *
      * @return Update|Update[]
      */
-    public function commandsHandler($webhook = false)
+    public function commandsHandler($webhook = false, array $params = [])
     {
         if ($webhook) {
             $update = $this->getWebhookUpdates();
@@ -1322,7 +1323,7 @@ class Api
             return $update;
         }
 
-        $updates = $this->getUpdates();
+        $updates = $this->getUpdates($params);
         $highestId = -1;
 
         foreach ($updates as $update) {


### PR DESCRIPTION
I'm using `$update = $telegram->commandsHandler();` in production and discovered that it doesn't use long polling. To make it use long polling I had to rewrite `commandsHandler()` with a call to `getUpdates()` with  `timeout` parameter set.

It would be much simpler to passthrough `timeout` from the scope I'm calling `commandsHandler()` in the first place.
I.e.  `$update = $telegram->commandsHandler(false, ['timeout' => 30]);`