### PR TITLE
\CommandsHandler::updatesTruncate

### DIFF
--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -317,7 +317,7 @@ abstract class Command implements CommandInterface
 
     private function cutTextBetween(Collection $splice)
     {
-        return substr(
+        return mb_substr(
             $this->getUpdate()->getMessage()->text,
             $splice->first(),
             $splice->last() - $splice->first()
@@ -326,7 +326,7 @@ abstract class Command implements CommandInterface
 
     private function cutTextFrom(Collection $splice)
     {
-        return substr(
+        return mb_substr(
             $this->getUpdate()->getMessage()->text,
             $splice->first()
         );

--- a/src/Commands/CommandBus.php
+++ b/src/Commands/CommandBus.php
@@ -150,7 +150,7 @@ class CommandBus extends AnswerBus
             throw new \InvalidArgumentException('Message is empty, Cannot parse for command');
         }
 
-        $command = substr(
+        $command = mb_substr(
             $text,
             $offset + 1,
             $length - 1

--- a/src/Exceptions/TelegramResponseException.php
+++ b/src/Exceptions/TelegramResponseException.php
@@ -26,7 +26,7 @@ class TelegramResponseException extends TelegramSDKException
         $this->response = $response;
         $this->responseData = $response->getDecodedBody();
 
-        $errorMessage = $this->get('description', 'Unknown error from API Response.');
+        $errorMessage = $this->get('description', $previousException ? $previousException->getMessage() : 'Unknown error from API Response.');
         $errorCode = $this->get('error_code', -1);
 
         parent::__construct($errorMessage, $errorCode, $previousException);
@@ -61,6 +61,10 @@ class TelegramResponseException extends TelegramSDKException
         if (isset($data['ok'], $data['error_code']) && $data['ok'] === false) {
             $code = $data['error_code'];
             $message = $data['description'] ?? 'Unknown error from API.';
+        } else {
+            print_r($data);
+            $message = \end($data);
+            //$message = ‌‌\current($data);
         }
 
         // Others

--- a/src/TelegramResponse.php
+++ b/src/TelegramResponse.php
@@ -89,7 +89,7 @@ class TelegramResponse
      */
     public function isError(): bool
     {
-        return isset($this->decodedBody['ok']) && ($this->decodedBody['ok'] === false);
+        return !isset($this->decodedBody['ok'])  || (isset($this->decodedBody['ok']) && ($this->decodedBody['ok'] === false));
     }
 
     /**

--- a/src/Traits/Http.php
+++ b/src/Traits/Http.php
@@ -340,6 +340,13 @@ trait Http
             throw CouldNotUploadInputFile::missingParam($inputFileField);
         }
 
+        $inputFileValue = $params[$inputFileField];
+
+        /** pass url drirect to telegram without dowload file via  InputFile*/
+        if (is_string($inputFileValue) && InputFile::create($inputFileValue)->isFileRemote()) {
+            return;
+        }
+
         //All file-paths, urls, or file resources should be provided by using the InputFile object
         if (! $params[$inputFileField] instanceof InputFile) {
             throw CouldNotUploadInputFile::inputFileParameterShouldBeInputFileEntity($inputFileField);


### PR DESCRIPTION
Truncate inbound updates Queue on Telegram server in new method \Telegram\Bot\Traits\CommandsHandler::updatesTruncate

I'd like to suggest feature CommandsHandler::updatesTruncate.

Rationale: if an exception is thrown in the body of the command handler, updates (including those containing commands) are not deleted from the server, and the next attempt to request and process messages from the server will also end with an error in the same place.

After the interception (in the main loop) of the unhandled exception inside the command itself, you need to imagine the ability to clear (truncate) the command queue on the server.
