### PR TITLE
Added laravel config file to 'config' group

### DIFF
--- a/src/Laravel/TelegramServiceProvider.php
+++ b/src/Laravel/TelegramServiceProvider.php
@@ -43,7 +43,7 @@ class TelegramServiceProvider extends ServiceProvider
         $source = __DIR__.'/config/telegram.php';
 
         if ($app instanceof LaravelApplication && $app->runningInConsole()) {
-            $this->publishes([$source => config_path('telegram.php')]);
+            $this->publishes([$source => config_path('telegram.php')], 'config');
         } elseif ($app instanceof LumenApplication) {
             $app->configure('telegram');
         }


### PR DESCRIPTION
With this improvement you can publish this package's laravel configuration file using

php artisan vendor:publish --provider="Telegram\Bot\Laravel\TelegramServiceProvider" --tag=config

Or when you publish all your application's configuration file using 

php artisan vendor:publish --tag=config

And if you want to publish all of this package's files regardless of the group, you can still use the default

php artisan vendor:publish --provider="Telegram\Bot\Laravel\TelegramServiceProvider"

