### PR TITLE
Update TelegramResponseException.php

### DIFF
--- a/src/Exceptions/TelegramResponseException.php
+++ b/src/Exceptions/TelegramResponseException.php
@@ -55,7 +55,7 @@ class TelegramResponseException extends TelegramSDKException
         }
 
         // Others
-        return new static($response, new TelegramOtherException($message, $code));
+        throw new static($response, new TelegramOtherException($message, $code));
     }
 
     /**


### PR DESCRIPTION
Using "return" instead 'throw' may cause not throwing any exception when surround "sendMessage" with "try...catch", making  do exiting from execution....
I.E. when bot try sending message to some user that "block bot" (by unsubscribing...), I can't cach this error and my bot stop execution.