### PR TITLE
Bot API 4.4

### DIFF
--- a/src/Methods/Chat.php
+++ b/src/Methods/Chat.php
@@ -5,6 +5,7 @@ namespace Telegram\Bot\Methods;
 use Telegram\Bot\Traits\Http;
 use Telegram\Bot\Objects\ChatMember;
 use Telegram\Bot\FileUpload\InputFile;
+use Telegram\Bot\Objects\ChatPermissions;
 use Telegram\Bot\Objects\Chat as ChatObject;
 use Telegram\Bot\Exceptions\TelegramSDKException;
 
@@ -357,14 +358,10 @@ trait Chat
      *
      * @param array    $params                    [
      *
-     * @var int|string $chat_id                   Required. Unique identifier for the target group or username of the target supergroup (in the format @supergroupusername)
-     * @var int        $user_id                   Required. Unique identifier of the target user.
-     * @var int        $until_date                (Optional). Date when restrictions will be lifted for the user, unix time. If user is restricted for more than 366 days or less than 30 seconds from the current time, they are considered to be restricted forever.
-     * @var bool       $can_send_messages         (Optional). Pass True, if the user can send text messages, contacts, locations and venues
-     * @var bool       $can_send_media_messages   (Optional). Pass True, if the user can send audios, documents, photos, videos, video notes and voice notes, implies can_send_messages
-     * @var bool       $can_send_other_messages   (Optional). Pass True, if the user can send animations, games, stickers and use inline bots, implies can_send_media_messages
-     * @var bool       $can_add_web_page_previews (Optional). Pass True, if the user may add web page previews to their messages, implies can_send_media_messages
-     *
+     * @var int|string      $chat_id        Required. Unique identifier for the target group or username of the target supergroup (in the format @supergroupusername)
+     * @var int             $user_id        Required. Unique identifier of the target user.
+     * @var ChatPermissions $permissions    Required.  New user permissions
+     * @var int             $until_date     (Optional). Date when restrictions will be lifted for the user, unix time. If user is restricted for more than 366 days or less than 30 seconds from the current time, they are considered to be restricted forever.
      * ]
      *
      * @throws TelegramSDKException
@@ -424,6 +421,38 @@ trait Chat
     public function promoteChatMember(array $params): bool
     {
         $response = $this->post('promoteChatMember', $params);
+
+        return $response->getResult();
+    }
+
+    /**
+     * Use this method to set default chat permissions for all members.
+     * The bot must be an administrator in the group or a supergroup for this to work and
+     * must have the can_restrict_members admin rights
+     *
+     * <code>
+     * $params = [
+     *   'chat_id'               => '',
+     *   'permissions'           => '',
+     * ];
+     * </code>
+     *
+     * @link https://core.telegram.org/bots/api#setchatpermissions
+     *
+     * @param array         $params      [
+     *
+     * @var int|string      $chat_id     Required. Unique identifier for the target group or username of the target supergroup (in the format @supergroupusername)
+     * @var ChatPermissions $permissions Required. New default chat permissions
+     *
+     * ]
+     *
+     * @throws TelegramSDKException
+     *
+     * @return bool
+     */
+    public function setChatPermissions(array $params): bool
+    {
+        $response = $this->post('setChatPermissions', $params);
 
         return $response->getResult();
     }

--- a/src/Methods/Stickers.php
+++ b/src/Methods/Stickers.php
@@ -17,7 +17,7 @@ use Telegram\Bot\Objects\Message as MessageObject;
 trait Stickers
 {
     /**
-     * Send .webp stickers.
+     * Use this method to send static .WEBP or animated .TGS stickers.
      *
      * <code>
      * $params = [

--- a/src/Objects/Chat.php
+++ b/src/Objects/Chat.php
@@ -8,19 +8,19 @@ use Telegram\Bot\Objects\Inputmedia\InputMedia;
  * Class Chat.
  *
  *
- * @property int        $id                           Unique identifier for this chat, not exceeding 1e13 by absolute value.
- * @property string     $type                         Type of chat, can be either 'private', 'group', 'supergroup' or 'channel'.
- * @property string     $title                        (Optional). Title, for channels and group chats.
- * @property string     $username                     (Optional). Username, for private chats and channels if available
- * @property string     $firstName                    (Optional). First name of the other party in a private chat
- * @property string     $lastName                     (Optional). Last name of the other party in a private chat
- * @property bool       $allMembersAreAdministrators  (Optional). True if a group has ‘All Members Are Admins’ enabled.
- * @property InputMedia $photo                        (Optional). Chat photo. Returned only in getChat.
- * @property string     $description                  (Optional). Description, for supergroups and channel chats. Returned only in getChat.
- * @property string     $inviteLink                   (Optional). Chat invite link, for supergroups and channel chats. Returned only in getChat.
- * @property Message    $pinnedMessage                (Optional). Pinned message, for groups, supergroups and channels. Returned only in getChat.
- * @property string     $stickerSetName               (Optional). For supergroups, name of group sticker set. Returned only in getChat.
- * @property bool       $canSetStickerSet             (Optional). True, if the bot can change the group sticker set. Returned only in getChat.
+ * @property int             $id                           Unique identifier for this chat, not exceeding 1e13 by absolute value.
+ * @property string          $type                         Type of chat, can be either 'private', 'group', 'supergroup' or 'channel'.
+ * @property string          $title                        (Optional). Title, for channels and group chats.
+ * @property string          $username                     (Optional). Username, for private chats and channels if available
+ * @property string          $firstName                    (Optional). First name of the other party in a private chat
+ * @property string          $lastName                     (Optional). Last name of the other party in a private chat
+ * @property InputMedia      $photo                        (Optional). Chat photo. Returned only in getChat.
+ * @property string          $description                  (Optional). Description, for groups, supergroups and channel chats. Returned only in getChat.
+ * @property string          $inviteLink                   (Optional). Chat invite link, for groups, supergroups and channel chats. Each administrator in a chat generates their own invite links, so the bot must first generate the link using exportChatInviteLink. Returned only in getChat.
+ * @property Message         $pinnedMessage                (Optional). Pinned message, for groups, supergroups and channels. Returned only in getChat.
+ * @property ChatPermissions $permissions                  (Optional). Pinned message, for groups, supergroups and channels. Returned only in getChat.
+ * @property string          $stickerSetName               (Optional). For supergroups, name of group sticker set. Returned only in getChat.
+ * @property bool            $canSetStickerSet             (Optional). True, if the bot can change the group sticker set. Returned only in getChat.
  */
 class Chat extends BaseObject
 {
@@ -30,8 +30,9 @@ class Chat extends BaseObject
     public function relations()
     {
         return [
-            'photo' => InputMedia::class,
+            'photo'          => InputMedia::class,
             'pinned_message' => Message::class,
+            'permissions'    => ChatPermissions::class,
         ];
     }
 }

--- a/src/Objects/ChatMember.php
+++ b/src/Objects/ChatMember.php
@@ -9,17 +9,17 @@ namespace Telegram\Bot\Objects;
  * @property string $status                          (Optional). The member's status in the chat. Can be “creator”, “administrator”, “member”, “left” or “kicked”
  * @property int    $untilDate                       (Optional). Restictred and kicked only. Date when restrictions will be lifted for this user, unix time
  * @property bool   $canBeEdited                     (Optional). Administrators only. True, if the bot is allowed to edit administrator privileges of that user
- * @property bool   $canChangeInfo                   (Optional). Administrators only. True, if the administrator can change the chat title, photo and other settings
  * @property bool   $canPostMessages                 (Optional). Administrators only. True, if the administrator can post in the channel, channels only
  * @property bool   $canEditMessages                 (Optional). Administrators only. True, if the administrator can edit messages of other users, channels only
  * @property bool   $canDeleteMessages               (Optional). Administrators only. True, if the administrator can delete messages of other users
- * @property bool   $canInviteUsers                  (Optional). Administrators only. True, if the administrator can invite new users to the chat
- * @property bool   $canRestrictMembers              (Optional). Administrators only. True, if the administrator can restrict, ban or unban chat members
- * @property bool   $canPinMessages                  (Optional). Administrators only. True, if the administrator can pin messages, supergroups only
  * @property bool   $canPromoteMembers               (Optional). Administrators only. True, if the administrator can add new administrators with a subset of his own privileges or demote administrators that he has promoted, directly or indirectly (promoted by administrators that were appointed by the user)
+ * @property bool   $canChangeInfo                   (Optional). Administrators and restricted only. True, if the administrator can change the chat title, photo and other settings
+ * @property bool   $canInviteUsers                  (Optional). Administrators and restricted only. True, if the administrator can invite new users to the chat
+ * @property bool   $canPinMessages                  (Optional). Administrators and restricted only. True, if the administrator can pin messages, supergroups only
  * @property bool   $isMember                        (Optional). Restricted only. True, if the user is a member of the chat at the moment of the request
  * @property bool   $canSendMessages                 (Optional). Restricted only. True, if the user can send text messages, contacts, locations and venues
  * @property bool   $canSendMediaMessages            (Optional). Restricted only. True, if the user can send audios, documents, photos, videos, video notes and voice notes, implies can_send_messages
+ * @property bool   $canSendPolls                    (Optional). Restricted only. True, if the user is allowed to send polls
  * @property bool   $canSendOtherMessages            (Optional). Restricted only. True, if the user can send animations, games, stickers and use inline bots, implies can_send_media_messages
  * @property bool   $canAddWebPagePreviews           (Optional). Restricted only. True, if user may add web page previews to his messages, implies can_send_media_messages
  */

--- a/src/Objects/ChatPermissions.php
+++ b/src/Objects/ChatPermissions.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Telegram\Bot\Objects;
+
+/**
+ * Class ChatPermissions.
+ *
+ * @property bool $canSendMessages                        (Optional). True, if the user is allowed to send text messages, contacts, locations and venues
+ * @property bool $canSendMediaMessages                   (Optional). True, if the user is allowed to send audios, documents, photos, videos, video notes and voice notes, implies can_send_messages
+ * @property bool $canSendPolls                           (Optional). True, if the user is allowed to send polls, implies can_send_messages
+ * @property bool $canSendOtherMessages                   (Optional). True, if the user is allowed to send animations, games, stickers and use inline bots, implies can_send_media_messages
+ * @property bool $canAddWebPagePreviews                  (Optional). True, if the user is allowed to add web page previews to their messages, implies can_send_media_messages
+ * @property bool $canChangeInfo                          (Optional). True, if the user is allowed to change the chat title, photo and other settings. Ignored in public supergroups
+ * @property bool $canInviteUsers                         (Optional). True, if the user is allowed to invite new users to the chat
+ * @property bool $canPinMessages                         (Optional). True, if the user is allowed to pin messages. Ignored in public supergroups
+ */
+class ChatPermissions extends BaseObject
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function relations()
+    {
+        return [
+            'user' => User::class,
+        ];
+    }
+}

--- a/src/Objects/ChatPhoto.php
+++ b/src/Objects/ChatPhoto.php
@@ -6,8 +6,8 @@ namespace Telegram\Bot\Objects;
  * Class ChatPhoto.
  *
  *
- * @property string $smallFileId   Unique file identifier of small (160x160) chat photo. This file_id can be used only for photo download.
- * @property string $bigFileId     Unique file identifier of big (640x640) chat photo. This file_id can be used only for photo download.
+ * @property string $smallFileId   Unique file identifier of small (160x160) chat photo. This file_id can be used only for photo download. This file_id can be used only for photo download and only for as long as the photo is not changed.
+ * @property string $bigFileId     Unique file identifier of big (640x640) chat photo. This file_id can be used only for photo download. This file_id can be used only for photo download and only for as long as the photo is not changed.
  */
 class ChatPhoto extends BaseObject
 {

--- a/src/Objects/Sticker.php
+++ b/src/Objects/Sticker.php
@@ -9,6 +9,7 @@ namespace Telegram\Bot\Objects;
  * @property string       $fileId              Unique identifier for this file.
  * @property int          $width               Sticker width.
  * @property int          $height              Sticker height.
+ * @property bool         $isAnimated          True, if the sticker is animated.
  * @property PhotoSize    $thumb               (Optional). Sticker thumbnail in .webp or .jpg format.
  * @property string       $emoji               (Optional). Emoji associated with the sticker
  * @property string       $setName             (Optional). Name of the sticker set to which the sticker belongs

--- a/src/Objects/StickerSet.php
+++ b/src/Objects/StickerSet.php
@@ -7,6 +7,7 @@ namespace Telegram\Bot\Objects;
  *
  * @property string    $name               Sticker set name
  * @property string    $title              Sticker set title
+ * @property bool      $isAnimated         True, if the sticker set contains animated stickers
  * @property bool      $containsMasks      True, if the sticker set contains masks
  * @property Sticker[] $stickers           List of all set stickers
  */


### PR DESCRIPTION
July 29, 2019

Added support for animated stickers. New field is_animated in Sticker and StickerSet objects, animated stickers can now be used in sendSticker and InlineQueryResultCachedSticker.

Added support for default permissions in groups. New object ChatPermissions, containing actions which a member can take in a chat. New field permissions in the Chat object; new method setChatPermissions.

The field all_members_are_administrators has been removed from the documentation for the Chat object. The field is still returned in the object for backward compatibility, but new bots should use the permissions field instead.

Added support for more permissions for group and supergroup members: added the new field can_send_polls to ChatMember object, added can_change_info, can_invite_users, can_pin_messages in ChatMember object for restricted users (previously available only for administrators).

The method restrictChatMember now takes the new user permissions in a single argument of the type ChatPermissions. The old way of passing parameters will keep working for a while for backward compatibility.

Added description support for basic groups (previously available in supergroups and channel chats). You can pass a group's chat_id to setChatDescription and receive the group's description in the Chat object in the response to getChat method.

Added invite_link support for basic groups (previously available in supergroups and channel chats). 

You can pass a group's chat_id to exportChatInviteLink and receive the group's invite link in the Chat object in the response to getChat method.

File identifiers from the ChatPhoto object are now invalidated and can no longer be used whenever the photo is changed.

All webhook requests from the Bot API are now coming from the subnets 149.154.160.0/20 and 91.108.4.0/22. Most users won't need to do anything to continue receiving webhooks. If you control inbound access with a firewall, you may need to update your configuration. You can always find the list of actual IP addresses of servers used to send webhooks there: https://core.telegram.org/bots/webhooks.

As of the next Bot API update (version 4.5), nested MessageEntity objects will be allowed in message texts and captions. Please make sure that your code can correctly handle such entities.