### PR TITLE
Fixed removed string/array helpers for laravel 6

### DIFF
--- a/src/Answers/Answerable.php
+++ b/src/Answers/Answerable.php
@@ -4,6 +4,7 @@ namespace Telegram\Bot\Answers;
 
 use Telegram\Bot\Api;
 use Telegram\Bot\Objects\Update;
+use Illuminate\Support\Str;
 
 /**
  * Class Answer
@@ -45,7 +46,7 @@ trait Answerable
             throw new \BadMethodCallException("Method [$method] does not exist.");
         }
         
-        $reply_name = studly_case(substr($method, 9));
+        $reply_name = Str::studly(substr($method, 9));
         $methodName = 'send' . $reply_name;
 
         if (!method_exists($this->telegram, $methodName)) {

--- a/src/Api.php
+++ b/src/Api.php
@@ -18,6 +18,7 @@ use Telegram\Bot\Objects\Update;
 use Telegram\Bot\Objects\User;
 use Telegram\Bot\Objects\UserProfilePhotos;
 use Telegram\Bot\Keyboard\Keyboard;
+use Illuminate\Support\Str;
 
 /**
  * Class Api.
@@ -1555,7 +1556,7 @@ class Api
         $action = substr($method, 0, 3);
         if ($action === 'get') {
             /* @noinspection PhpUndefinedFunctionInspection */
-            $class_name = studly_case(substr($method, 3));
+            $class_name = Str::studly(substr($method, 3));
             $class = 'Telegram\Bot\Objects\\'.$class_name;
             $response = $this->post($method, $arguments[0] ?: []);
 

--- a/src/BotsManager.php
+++ b/src/BotsManager.php
@@ -4,6 +4,7 @@ namespace Telegram\Bot;
 
 use Illuminate\Contracts\Container\Container;
 use InvalidArgumentException;
+use Illuminate\Support\Arr;
 
 /**
  * Class BotsManager
@@ -71,7 +72,7 @@ class BotsManager
         $name = $name ?: $this->getDefaultBot();
 
         $bots = $this->getConfig('bots');
-        if (!is_array($config = array_get($bots, $name)) && !$config) {
+        if (!is_array($config = Arr::get($bots, $name)) && !$config) {
             throw new InvalidArgumentException("Bot [$name] not configured.");
         }
 
@@ -136,7 +137,7 @@ class BotsManager
      */
     public function getConfig($key, $default = null)
     {
-        return array_get($this->config, $key, $default);
+        return Arr::get($this->config, $key, $default);
     }
 
     /**
@@ -158,7 +159,7 @@ class BotsManager
      */
     public function setDefaultBot($name)
     {
-        array_set($this->config, 'default', $name);
+        Arr::set($this->config, 'default', $name);
 
         return $this;
     }
@@ -196,8 +197,8 @@ class BotsManager
     {
         $config = $this->getBotConfig($name);
 
-        $token = array_get($config, 'token');
-        $commands = array_get($config, 'commands', []);
+        $token = Arr::get($config, 'token');
+        $commands = Arr::get($config, 'commands', []);
 
         $telegram = new Api(
             $token,

--- a/src/Keyboard/Base.php
+++ b/src/Keyboard/Base.php
@@ -2,6 +2,7 @@
 namespace Telegram\Bot\Keyboard;
 
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 
 class Base extends Collection
 {
@@ -21,7 +22,7 @@ class Base extends Collection
             return parent::__call($method, $args);
         }
 
-        $property = snake_case(substr($method, 3));
+        $property = Str::snake(substr($method, 3));
         $this->items[$property] = $args[0];
 
         return $this;

--- a/src/Objects/BaseObject.php
+++ b/src/Objects/BaseObject.php
@@ -3,6 +3,8 @@
 namespace Telegram\Bot\Objects;
 
 use Illuminate\Support\Collection;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 
 /**
  * Class BaseObject.
@@ -89,7 +91,7 @@ abstract class BaseObject extends Collection
      */
     public function getRawResult($data)
     {
-        return array_get($data, 'result', $data);
+        return Arr::get($data, 'result', $data);
     }
 
     /**
@@ -99,7 +101,7 @@ abstract class BaseObject extends Collection
      */
     public function getStatus()
     {
-        return array_get($this->items, 'ok', false);
+        return Arr::get($this->items, 'ok', false);
     }
 
     /**
@@ -116,7 +118,7 @@ abstract class BaseObject extends Collection
         if ($action !== 'get') {
             return false;
         }
-        $property = snake_case(substr($name, 3));
+        $property = Str::snake(substr($name, 3));
         $response = $this->get($property);
 
         // Map relative property to an object

--- a/src/Objects/InlineQuery/InlineBaseObject.php
+++ b/src/Objects/InlineQuery/InlineBaseObject.php
@@ -3,6 +3,7 @@ namespace Telegram\Bot\Objects\InlineQuery;
 
 use BadMethodCallException;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 
 abstract class InlineBaseObject extends Collection
 {
@@ -20,7 +21,7 @@ abstract class InlineBaseObject extends Collection
         $action = substr($name, 0, 3);
 
         if ($action === 'set') {
-            $property = snake_case(substr($name, 3));
+            $property = Str::snake(substr($name, 3));
             $this->put($property, $arguments[0]);
 
             return $this;


### PR DESCRIPTION
String/Array Helpers have been removed in Laravel 6.0, (see https://laravel.com/docs/6.0/upgrade#helpers), fixed it to use the FQCN.