### PR TITLE
fix issue in sendMediaGroup

### DIFF
--- a/src/Methods/Message.php
+++ b/src/Methods/Message.php
@@ -427,7 +427,7 @@ trait Message
      */
     public function sendMediaGroup(array $params)
     {
-        $response = $this->uploadFile('sendMediaGroup', $params, 'video_note');
+        $response = $this->uploadFile('sendMediaGroup', $params, 'media');
 
         return new MessageObject($response->getDecodedBody());
     }

--- a/src/Traits/Http.php
+++ b/src/Traits/Http.php
@@ -342,7 +342,7 @@ trait Http
         }
 
         //All file-paths, urls, or file resources should be provided by using the InputFile object
-        if ((!$params[$inputFileField] instanceof InputFile) && (!is_json($params[$inputFileField]))) {
+        if ((!$params[$inputFileField] instanceof InputFile) && (!$this->is_json($params[$inputFileField]))) {
             throw CouldNotUploadInputFile::inputFileParameterShouldBeInputFileEntity($inputFileField);
         }
     }

--- a/src/Traits/Http.php
+++ b/src/Traits/Http.php
@@ -342,7 +342,7 @@ trait Http
         }
 
         //All file-paths, urls, or file resources should be provided by using the InputFile object
-        if (! $params[$inputFileField] instanceof InputFile) {
+        if ((!$params[$inputFileField] instanceof InputFile) && (!is_json($params[$inputFileField]))) {
             throw CouldNotUploadInputFile::inputFileParameterShouldBeInputFileEntity($inputFileField);
         }
     }

--- a/src/Traits/Validator.php
+++ b/src/Traits/Validator.php
@@ -13,7 +13,7 @@ trait Validator
      * Determine given param in params array is a file id.
      *
      * @param string $inputFileField
-     * @param array $params
+     * @param array  $params
      *
      * @return bool
      */
@@ -43,7 +43,7 @@ trait Validator
      */
     protected function isFileId($value): bool
     {
-        if (!is_string($value)) {
+        if (! is_string($value)) {
             return false;
         }
 
@@ -59,7 +59,7 @@ trait Validator
      */
     protected function isUrl($value): bool
     {
-        return (bool)filter_var($value, FILTER_VALIDATE_URL);
+        return (bool) filter_var($value, FILTER_VALIDATE_URL);
     }
 
     /**

--- a/src/Traits/Validator.php
+++ b/src/Traits/Validator.php
@@ -61,4 +61,16 @@ trait Validator
     {
         return (bool) filter_var($value, FILTER_VALIDATE_URL);
     }
+
+    /**
+     * Determine given string is a json object.
+     *
+     * @param string $string  A json string
+     * @return bool
+     */
+    function is_json($string) :bool
+    {
+        json_decode($string);
+        return (json_last_error() == JSON_ERROR_NONE);
+    }
 }

--- a/src/Traits/Validator.php
+++ b/src/Traits/Validator.php
@@ -13,7 +13,7 @@ trait Validator
      * Determine given param in params array is a file id.
      *
      * @param string $inputFileField
-     * @param array  $params
+     * @param array $params
      *
      * @return bool
      */
@@ -43,7 +43,7 @@ trait Validator
      */
     protected function isFileId($value): bool
     {
-        if (! is_string($value)) {
+        if (!is_string($value)) {
             return false;
         }
 
@@ -59,16 +59,16 @@ trait Validator
      */
     protected function isUrl($value): bool
     {
-        return (bool) filter_var($value, FILTER_VALIDATE_URL);
+        return (bool)filter_var($value, FILTER_VALIDATE_URL);
     }
 
     /**
      * Determine given string is a json object.
      *
-     * @param string $string  A json string
+     * @param string $string A json string
      * @return bool
      */
-    function is_json($string) :bool
+    protected function is_json($string): bool
     {
         json_decode($string);
         return (json_last_error() == JSON_ERROR_NONE);


### PR DESCRIPTION
In the "sendMediaGroup" method the "inputFileField" key has been incorrectly set as "video_note" instead of "media". Also, since the "media" field is JSON serialized string and not an input field, as mentioned in the Telegram API Docs, I updated the "validateInputFileField" in "Traits/Http.php" class to support this case.
Thanks.
