### PR TITLE
Bot API 4.5

### DIFF
--- a/src/Methods/Chat.php
+++ b/src/Methods/Chat.php
@@ -426,6 +426,40 @@ trait Chat
     }
 
     /**
+     * Use this method to set a custom title for an administrator in a supergroup promoted by the bot.
+     *
+     * Returns True on success.
+     *
+     * <code>
+     * $params = [
+     *   'chat_id'               => '',
+     *   'user_id'               => '',
+     *   'custom_title'           => '',
+     * ];
+     * </code>
+     *
+     * @link https://core.telegram.org/bots/api#setchatadministratorcustomtitle
+     *
+     * @param array         $params      [
+     *
+     * @var int|string      $chat_id      Required. Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
+     * @var int             $user_id      Required. Unique identifier of the target user
+     * @var string          $custom_title Required. New custom title for the administrator; 0-16 characters, emoji are not allowed
+     *
+     * ]
+     *
+     * @throws TelegramSDKException
+     *
+     * @return bool
+     */
+    public function setChatAdministratorCustomTitle(array $params): bool
+    {
+        $response = $this->post('setChatAdministratorCustomTitle', $params);
+
+        return $response->getResult();
+    }
+
+    /**
      * Use this method to set default chat permissions for all members.
      * The bot must be an administrator in the group or a supergroup for this to work and
      * must have the can_restrict_members admin rights

--- a/src/Objects/Animation.php
+++ b/src/Objects/Animation.php
@@ -5,14 +5,15 @@ namespace Telegram\Bot\Objects;
 /**
  * Class Animation.
  *
- * @property string      $fileId   Unique file identifier.
- * @property int         $width    Video width as defined by sender.
- * @property int         $height   Video height as defined by sender.
- * @property int         $duration Duration of the video in seconds as defined by sender.
- * @property PhotoSize   $thumb    (Optional). Animation thumbnail as defined by sender.
- * @property string      $fileName (Optional). Original animation filename as defined by sender.
- * @property string      $mimeType (Optional). MIME type of the file as defined by sender.
- * @property int         $fileSize (Optional). File size.
+ * @property string    $fileId           Unique file identifier.
+ * @property string    $fileUniqueId     Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
+ * @property int       $width            Video width as defined by sender.
+ * @property int       $height           Video height as defined by sender.
+ * @property int       $duration         Duration of the video in seconds as defined by sender.
+ * @property PhotoSize $thumb            (Optional). Animation thumbnail as defined by sender.
+ * @property string    $fileName         (Optional). Original animation filename as defined by sender.
+ * @property string    $mimeType         (Optional). MIME type of the file as defined by sender.
+ * @property int       $fileSize         (Optional). File size.
  */
 class Animation extends BaseObject
 {

--- a/src/Objects/Audio.php
+++ b/src/Objects/Audio.php
@@ -6,13 +6,14 @@ namespace Telegram\Bot\Objects;
  * Class Audio.
  *
  *
- * @property string    $fileId     Unique identifier for this file.
- * @property int       $duration   Duration of the audio in seconds as defined by sender.
- * @property string    $performer  (Optional). Performer of the audio as defined by sender or by audio tags.
- * @property string    $title      (Optional). Title of the audio as defined by sender or by audio tags.
- * @property string    $mimeType   (Optional). MIME type of the file as defined by sender.
- * @property int       $fileSize   (Optional). File size.
- * @property PhotoSize $thumb      (Optional). Thumbnail of the album cover to which the music file belongs
+ * @property string    $fileId           Unique identifier for this file.
+ * @property string    $fileUniqueId     Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
+ * @property int       $duration         Duration of the audio in seconds as defined by sender.
+ * @property string    $performer        (Optional). Performer of the audio as defined by sender or by audio tags.
+ * @property string    $title            (Optional). Title of the audio as defined by sender or by audio tags.
+ * @property string    $mimeType         (Optional). MIME type of the file as defined by sender.
+ * @property int       $fileSize         (Optional). File size.
+ * @property PhotoSize $thumb            (Optional). Thumbnail of the album cover to which the music file belongs
  */
 class Audio extends BaseObject
 {

--- a/src/Objects/Chat.php
+++ b/src/Objects/Chat.php
@@ -19,6 +19,7 @@ use Telegram\Bot\Objects\Inputmedia\InputMedia;
  * @property string          $inviteLink                   (Optional). Chat invite link, for groups, supergroups and channel chats. Each administrator in a chat generates their own invite links, so the bot must first generate the link using exportChatInviteLink. Returned only in getChat.
  * @property Message         $pinnedMessage                (Optional). Pinned message, for groups, supergroups and channels. Returned only in getChat.
  * @property ChatPermissions $permissions                  (Optional). Pinned message, for groups, supergroups and channels. Returned only in getChat.
+ * @property int             $slowModeDelay                (Optional). For supergroups, the minimum allowed delay between consecutive messages sent by each unpriviledged user. Returned only in getChat.
  * @property string          $stickerSetName               (Optional). For supergroups, name of group sticker set. Returned only in getChat.
  * @property bool            $canSetStickerSet             (Optional). True, if the bot can change the group sticker set. Returned only in getChat.
  */

--- a/src/Objects/ChatMember.php
+++ b/src/Objects/ChatMember.php
@@ -6,7 +6,8 @@ namespace Telegram\Bot\Objects;
  * Class ChatMember.
  *
  * @property User   $user                            Information about the user.
- * @property string $status                          (Optional). The member's status in the chat. Can be “creator”, “administrator”, “member”, “left” or “kicked”
+ * @property string $status                          The member's status in the chat. Can be “creator”, “administrator”, “member”, “left” or “kicked”
+ * @property string $customTitle                     (Optional). Owner and administrators only. Custom title for this user
  * @property int    $untilDate                       (Optional). Restictred and kicked only. Date when restrictions will be lifted for this user, unix time
  * @property bool   $canBeEdited                     (Optional). Administrators only. True, if the bot is allowed to edit administrator privileges of that user
  * @property bool   $canPostMessages                 (Optional). Administrators only. True, if the administrator can post in the channel, channels only

--- a/src/Objects/ChatPhoto.php
+++ b/src/Objects/ChatPhoto.php
@@ -6,8 +6,10 @@ namespace Telegram\Bot\Objects;
  * Class ChatPhoto.
  *
  *
- * @property string $smallFileId   Unique file identifier of small (160x160) chat photo. This file_id can be used only for photo download. This file_id can be used only for photo download and only for as long as the photo is not changed.
- * @property string $bigFileId     Unique file identifier of big (640x640) chat photo. This file_id can be used only for photo download. This file_id can be used only for photo download and only for as long as the photo is not changed.
+ * @property string $smallFileId         Unique file identifier of small (160x160) chat photo. This file_id can be used only for photo download. This file_id can be used only for photo download and only for as long as the photo is not changed.
+ * @property string $smallFileUniqueId   Unique file identifier of small (160x160) chat photo, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
+ * @property string $bigFileId           Unique file identifier of big (640x640) chat photo. This file_id can be used only for photo download. This file_id can be used only for photo download and only for as long as the photo is not changed.
+ * @property string $bigFileUniqueId     Unique file identifier of big (640x640) chat photo, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
  */
 class ChatPhoto extends BaseObject
 {

--- a/src/Objects/Document.php
+++ b/src/Objects/Document.php
@@ -6,11 +6,12 @@ namespace Telegram\Bot\Objects;
  * Class Document.
  *
  *
- * @property string       $fileId     Unique file identifier.
- * @property PhotoSize    $thumb      (Optional). Document thumbnail as defined by sender.
- * @property string       $fileName   (Optional). Original filename as defined by sender.
- * @property string       $mimeType   (Optional). MIME type of the file as defined by sender.
- * @property int          $fileSize   (Optional). File size.
+ * @property string    $fileId           Unique file identifier.
+ * @property string    $fileUniqueId     Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
+ * @property PhotoSize $thumb            (Optional). Document thumbnail as defined by sender.
+ * @property string    $fileName         (Optional). Original filename as defined by sender.
+ * @property string    $mimeType         (Optional). MIME type of the file as defined by sender.
+ * @property int       $fileSize         (Optional). File size.
  */
 class Document extends BaseObject
 {

--- a/src/Objects/File.php
+++ b/src/Objects/File.php
@@ -6,9 +6,10 @@ namespace Telegram\Bot\Objects;
  * Class File.
  *
  *
- * @property string   $fileId     Unique identifier for this file.
- * @property int      $fileSize   (Optional). File size, if known.
- * @property string   $filePath   (Optional). File path. Use 'https://api.telegram.org/file/bot<token>/<file_path>' to get the file.
+ * @property string $fileId         Unique identifier for this file.
+ * @property string $fileUniqueId   Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
+ * @property int    $fileSize       (Optional). File size, if known.
+ * @property string $filePath       (Optional). File path. Use 'https://api.telegram.org/file/bot<token>/<file_path>' to get the file.
  */
 class File extends BaseObject
 {

--- a/src/Objects/MessageEntity.php
+++ b/src/Objects/MessageEntity.php
@@ -5,7 +5,7 @@ namespace Telegram\Bot\Objects;
 /**
  * Class MessageEntity.
  *
- * @property string $type   Type of the entity. Can be mention (@username), hashtag, cashtag, bot_command, url, email, phone_number, bold (bold text), italic (italic text), code (monowidth string), pre (monowidth block), text_link (for clickable text URLs), text_mention (for users without usernames)
+ * @property string $type   Type of the entity. Can be “mention” (@username), “hashtag” (#hashtag), “cashtag” ($USD), “bot_command” (/start@jobs_bot), “url” (https://telegram.org), “email” (do-not-reply@telegram.org), “phone_number” (+1-212-555-0123), “bold” (bold text), “italic” (italic text), “underline” (underlined text), “strikethrough” (strikethrough text), “code” (monowidth string), “pre” (monowidth block), “text_link” (for clickable text URLs), “text_mention” (for users without usernames)
  * @property int    $offset Offset in UTF-16 code units to the start of the entity
  * @property int    $length Length of the entity in UTF-16 code units
  * @property string $url    (Optional). For "text_link" only, url that will be opened after user taps on the text.

--- a/src/Objects/Passport/PassportFile.php
+++ b/src/Objects/Passport/PassportFile.php
@@ -6,6 +6,7 @@ use Telegram\Bot\Objects\BaseObject;
 
 /**
  * @property string $fileId              Unique identifier for this file
+ * @property string $fileUniqueId        Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
  * @property int    $fileSize            File size
  * @property int    $fileDate            Unix time when the file was uploaded
  *

--- a/src/Objects/PhotoSize.php
+++ b/src/Objects/PhotoSize.php
@@ -6,10 +6,11 @@ namespace Telegram\Bot\Objects;
  * Class PhotoSize.
  *
  *
- * @property string   $fileId     Unique identifier for this file.
- * @property int      $width      Photo width.
- * @property int      $height     Photo height.
- * @property int      $fileSize   (Optional). File size.
+ * @property string $fileId         Unique identifier for this file.
+ * @property string $fileUniqueId   Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
+ * @property int    $width          Photo width.
+ * @property int    $height         Photo height.
+ * @property int    $fileSize       (Optional). File size.
  */
 class PhotoSize extends BaseObject
 {

--- a/src/Objects/Sticker.php
+++ b/src/Objects/Sticker.php
@@ -7,6 +7,7 @@ namespace Telegram\Bot\Objects;
  *
  *
  * @property string       $fileId              Unique identifier for this file.
+ * @property string       $fileUniqueId        Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
  * @property int          $width               Sticker width.
  * @property int          $height              Sticker height.
  * @property bool         $isAnimated          True, if the sticker is animated.

--- a/src/Objects/Video.php
+++ b/src/Objects/Video.php
@@ -6,13 +6,14 @@ namespace Telegram\Bot\Objects;
  * Class Video.
  *
  *
- * @property string       $fileId     Unique identifier for this file.
- * @property int          $width      Video width as defined by sender.
- * @property int          $height     Video height as defined by sender.
- * @property int          $duration   Duration of the video in seconds as defined by sender.
- * @property PhotoSize    $thumb      (Optional). Video thumbnail.
- * @property string       $mimeType   (Optional). Mime type of a file as defined by sender.
- * @property int          $fileSize   (Optional). File size.
+ * @property string    $fileId         Unique identifier for this file.
+ * @property string    $fileUniqueId   Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
+ * @property int       $width          Video width as defined by sender.
+ * @property int       $height         Video height as defined by sender.
+ * @property int       $duration       Duration of the video in seconds as defined by sender.
+ * @property PhotoSize $thumb          (Optional). Video thumbnail.
+ * @property string    $mimeType       (Optional). Mime type of a file as defined by sender.
+ * @property int       $fileSize       (Optional). File size.
  */
 class Video extends BaseObject
 {

--- a/src/Objects/VideoNote.php
+++ b/src/Objects/VideoNote.php
@@ -3,11 +3,12 @@
 namespace Telegram\Bot\Objects;
 
 /**
- * @property string       $fileId     Unique identifier for this file.
- * @property int          $length     Video width and height as defined by sender.
- * @property int          $duration   Duration of the video in seconds as defined by sender.
- * @property PhotoSize    $thumb      (Optional). Video thumbnail.
- * @property int          $fileSize   (Optional). File size.
+ * @property string    $fileId         Unique identifier for this file.
+ * @property string    $fileUniqueId   Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
+ * @property int       $length         Video width and height as defined by sender.
+ * @property int       $duration       Duration of the video in seconds as defined by sender.
+ * @property PhotoSize $thumb          (Optional). Video thumbnail.
+ * @property int       $fileSize       (Optional). File size.
  *
  * @link https://core.telegram.org/bots/api#videonote
  */

--- a/src/Objects/Voice.php
+++ b/src/Objects/Voice.php
@@ -6,10 +6,11 @@ namespace Telegram\Bot\Objects;
  * Class Voice.
  *
  *
- * @property string   $fileId     Unique identifier for this file.
- * @property int      $duration   Duration of the audio in seconds as defined by sender.
- * @property string   $mimeType   (Optional). MIME type of the file as defined by sender.
- * @property int      $fileSize   (Optional). File size.
+ * @property string $fileId         Unique identifier for this file.
+ * @property string $fileUniqueId   Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
+ * @property int    $duration       Duration of the audio in seconds as defined by sender.
+ * @property string $mimeType       (Optional). MIME type of the file as defined by sender.
+ * @property int    $fileSize       (Optional). File size.
  */
 class Voice extends BaseObject
 {


### PR DESCRIPTION
December 31, 2019

Added support for two new MessageEntity types, underline and strikethrough.
Added a new parse mode, MarkdownV2, which supports nested entities and two new entities __ (for underlined text) and ~ (for strikethrough text). Parse mode Markdown remains unchanged for backward compatibility.
Added the field file_unique_id to the objects Animation, Audio, Document, PassportFile, PhotoSize, Sticker, Video, VideoNote, Voice, File and the fields small_file_unique_id and big_file_unique_id to the object ChatPhoto. The new fields contain a unique file identifier, which is supposed to be the same over time and for different bots, but can't be used to download or reuse the file.
Added the field custom_title to the ChatMember object.
Added the new method setChatAdministratorCustomTitle to manage the custom titles of administrators promoted by the bot.
Added the field slow_mode_delay to the Chat object.

https://core.telegram.org/bots/api-changelog#december-31-2019

NOT IMPLEMENTED YET:
Added support for nested MessageEntity objects. Entities can now contain other entities. If two entities have common characters then one of them is fully contained inside the other.
Added support for nested entities and the new tags <u>/<ins> (for underlined text) and <s>/<strike>/<del> (for strikethrough text) in parse mode HTML.