### PR TITLE
Bot API 4.7

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -23,6 +23,7 @@ class Api
         Traits\CommandsHandler,
         Traits\HasContainer;
     use Methods\Chat,
+        Methods\Commands,
         Methods\EditMessage,
         Methods\Game,
         Methods\Get,

--- a/src/Methods/Commands.php
+++ b/src/Methods/Commands.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Telegram\Bot\Methods;
+
+use Telegram\Bot\Traits\Http;
+use Telegram\Bot\Objects\BotCommand;
+use Telegram\Bot\Exceptions\TelegramSDKException;
+
+/**
+ * Class Commands.
+ * @mixin Http
+ */
+trait Commands
+{
+
+    /**
+     * Get the current list of the bot's commands.
+     *
+     * @link https://core.telegram.org/bots/api#getmycommands
+     *
+     * @return BotCommand[]
+     * @throws TelegramSDKException
+     */
+    public function getMyCommands(): array
+    {
+        $response = $this->get('getMyCommands');
+
+        return collect($response->getResult())
+            ->map(function ($botCommand) {
+                return new BotCommand($botCommand);
+            })
+            ->all();
+    }
+
+    /**
+     * Change the list of the bot's commands.
+     *
+     * <code>
+     * $params = [
+     *   'commands'              => '',
+     * ];
+     * </code>
+     *
+     * @link https://core.telegram.org/bots/api#setmycommands
+     *
+     * @param array $params   [
+     *
+     * @var array   $commands Required. A JSON-serialized list of bot commands to be set as the list of the bot's commands. At most 100 commands can be specified.
+     *
+     * ]
+     *
+     * @throws TelegramSDKException
+     *
+     * @return Bool
+     */
+    public function setMyCommands(array $params): Bool
+    {
+        $params['commands'] = json_encode($params['commands']);
+
+        return $this->post('setMyCommands', $params)->getResult();
+    }
+}

--- a/src/Methods/Message.php
+++ b/src/Methods/Message.php
@@ -564,6 +564,42 @@ trait Message
     }
 
     /**
+     * Send a dice.
+     *
+     * Use this method to send a dice, which will have a random value from 1 to 6
+     *
+     * <code>
+     * $params = [
+     *   'chat_id'              => '',
+     *   'disable_notification' => '',
+     *   'reply_to_message_id'  => '',
+     *   'reply_markup'         => '',
+     * ];
+     * </code>
+     *
+     * @link https://core.telegram.org/bots/api#senddice
+     *
+     * @param array    $params               [
+     *
+     * @var int|string $chat_id              Required. Unique identifier for the target chat or username of the target channel (in the format @channelusername). A native poll can't be sent to a private chat.
+     * @var bool       $disable_notification Optional. Sends the message silently. Users will receive a notification with no sound.
+     * @var int        $reply_to_message_id  Optional. If the message is a reply, ID of the original message
+     * @var string     $reply_markup         Optional. Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+     *
+     * ]
+     *
+     * @throws TelegramSDKException
+     *
+     * @return MessageObject
+     */
+    public function sendDice(array $params): MessageObject
+    {
+        $response = $this->post('sendDice', $params);
+
+        return new MessageObject($response->getDecodedBody());
+    }
+
+    /**
      * Broadcast a Chat Action.
      *
      * <code>

--- a/src/Methods/Stickers.php
+++ b/src/Methods/Stickers.php
@@ -120,6 +120,7 @@ trait Stickers
      *   'name'              => '',
      *   'title'             => '',
      *   'png_sticker'       => '',
+     *   'tgs_sticker'       => '',
      *   'emojis'            => '',
      *   'contains_masks'    => '',
      *   'mask_position'     => '',
@@ -133,7 +134,8 @@ trait Stickers
      * @var int              $user_id        Required. User identifier of created sticker set owner
      * @var string           $name           Required. Short name of sticker set, to be used in t.me/addstickers/ URLs (e.g., animals). Can contain only english letters, digits and underscores. Must begin with a letter, can't contain consecutive underscores and must end in “_by_<bot username>”. <bot_username> is case insensitive. 1-64 characters.
      * @var string           $title          Required. Sticker set title, 1-64 characters
-     * @var InputFile|string $png_sticker    Required. Png image with the sticker, must be up to 512 kilobytes in size, dimensions must not exceed 512px, and either width or height must be exactly 512px. Pass a file_id as a String to send a file that already exists on the Telegram servers, pass an HTTP URL as a String for Telegram to get a file from the Internet, or upload a new one using multipart/form-data.
+     * @var InputFile|string $png_sticker    (Optional). Png image with the sticker, must be up to 512 kilobytes in size, dimensions must not exceed 512px, and either width or height must be exactly 512px. Pass a file_id as a String to send a file that already exists on the Telegram servers, pass an HTTP URL as a String for Telegram to get a file from the Internet, or upload a new one using multipart/form-data.
+     * @var InputFile        $tgs_sticker    (Optional). TGS animation with the sticker, uploaded using multipart/form-data. See https://core.telegram.org/animated_stickers#technical-requirements for technical requirements
      * @var string           $emojis         Required. One or more emoji corresponding to the sticker
      * @var bool             $contains_masks (Optional). Pass True, if a set of mask stickers should be created
      * @var MaskPosition     $mask_position  (Optional). A JSON-serialized object for position where the mask should be placed on faces
@@ -159,6 +161,7 @@ trait Stickers
      *   'user_id'           => '',
      *   'name'              => '',
      *   'png_sticker'       => '',
+     *   'tgs_sticker'       => '',
      *   'emojis'            => '',
      *   'mask_position'     => '',
      * ];
@@ -171,6 +174,7 @@ trait Stickers
      * @var int              $user_id       Required. User identifier of sticker set owner
      * @var string           $name          Required. Sticker set name
      * @var InputFile|string $png_sticker   Required. Png image with the sticker, must be up to 512 kilobytes in size, dimensions must not exceed 512px, and either width or height must be exactly 512px. Pass a file_id as a String to send a file that already exists on the Telegram servers, pass an HTTP URL as a String for Telegram to get a file from the Internet, or upload a new one using multipart/form-data.
+     * @var InputFile        $tgs_sticker   (Optional). TGS animation with the sticker, uploaded using multipart/form-data. See https://core.telegram.org/animated_stickers#technical-requirements for technical requirements
      * @var string           $emojis        Required. One or more emoji corresponding to the sticker
      * @var MaskPosition     $mask_position (Optional). A JSON-serialized object for position where the mask should be placed on faces
      *
@@ -244,4 +248,37 @@ trait Stickers
 
         return $response->getResult();
     }
+
+    /**
+     * Set the thumbnail of a sticker set
+     *
+     * <code>
+     * $params = [
+     *   'name'          => '',
+     *   'user_id'       => '',
+     *   'thumb'         => '',
+     * ];
+     * </code>
+     *
+     * @link https://core.telegram.org/bots/api#setstickersetthumb
+     *
+     * @param array          $params        [
+     *
+     * @var string           $name          Required. Sticker set name
+     * @var int              $user_id       Required. User identifier of sticker set owner
+     * @var InputFile|string $thumb         (Optional). A PNG image with the thumbnail, must be up to 128 kilobytes in size and have width and height exactly 100px, or a TGS animation with the thumbnail up to 32 kilobytes in size; see https://core.telegram.org/animated_stickers#technical-requirements for animated sticker technical requirements. Pass a file_id as a String to send a file that already exists on the Telegram servers, pass an HTTP URL as a String for Telegram to get a file from the Internet, or upload a new one using multipart/form-data. More info on Sending Files ». Animated sticker set thumbnail can't be uploaded via HTTP URL
+     *
+     * ]
+     *
+     * @throws TelegramSDKException
+     *
+     * @return bool
+     */
+    public function setStickerSetThumb(array $params): bool
+    {
+        $response = $this->uploadFile('setStickerSetThumb', $params, 'thumb');
+
+        return $response->getResult();
+    }
+
 }

--- a/src/Objects/BotCommand.php
+++ b/src/Objects/BotCommand.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Telegram\Bot\Objects;
+
+/**
+ * Class BotCommand.
+ *
+ * This object represents a bot command
+ *
+ * @property string    $command     Text of the command, 1-32 characters. Can contain only lowercase English letters, digits and underscores.
+ * @property string    $description Description of the command, 3-256 characters.
+ */
+class BotCommand extends BaseObject
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function relations()
+    {
+        return [];
+    }
+}

--- a/src/Objects/Dice.php
+++ b/src/Objects/Dice.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Telegram\Bot\Objects;
+
+/**
+ * Class Dice.
+ *
+ * (Yes, we're aware of the “proper” singular of die. But it's awkward, and we decided to help it change. One dice at a time!)
+ *
+ * @property int    $value     Value of the dice, 1-6
+ */
+class Dice extends BaseObject
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function relations()
+    {
+        return [];
+    }
+}

--- a/src/Objects/StickerSet.php
+++ b/src/Objects/StickerSet.php
@@ -10,6 +10,7 @@ namespace Telegram\Bot\Objects;
  * @property bool      $isAnimated         True, if the sticker set contains animated stickers
  * @property bool      $containsMasks      True, if the sticker set contains masks
  * @property Sticker[] $stickers           List of all set stickers
+ * @property PhotoSize $thumb              Optional. Sticker set thumbnail in the .WEBP or .TGS format
  */
 class StickerSet extends BaseObject
 {
@@ -20,6 +21,7 @@ class StickerSet extends BaseObject
     {
         return [
             'stickers' => Sticker::class,
+            'thumb'    => PhotoSize::class,
         ];
     }
 }


### PR DESCRIPTION
March 30, 2020

Added the method sendDice for sending a dice message, which will have a random value from 1 to 6. (Yes, we're aware of the “proper” singular of die. But it's awkward, and we decided to help it change. One dice at a time!)
Added the field dice to the Message object.
Added the method getMyCommands for getting the current list of the bot's commands.
Added the method setMyCommands for changing the list of the bot's commands through the Bot API instead of @BotFather.
Added the ability to create animated sticker sets by specifying the parameter tgs_sticker instead of png_sticker in the method createNewStickerSet.
Added the ability to add animated stickers to sets created by the bot by specifying the parameter tgs_sticker instead of png_sticker in the method addStickerToSet.
Added the field thumb to the StickerSet object.
Added the ability to change thumbnails of sticker sets created by the bot using the method setStickerSetThumb.

Please note. Testing the stickerset thumbnails was not done. Don't have the time to be making stickers!