### PR TITLE
Replace "array_wrap" with "Arr::wrap"

### DIFF
--- a/src/Methods/Payments.php
+++ b/src/Methods/Payments.php
@@ -7,6 +7,7 @@ use Telegram\Bot\Objects\Message;
 use Telegram\Bot\Objects\Payments\LabeledPrice;
 use Telegram\Bot\Objects\Payments\ShippingOption;
 use Telegram\Bot\Traits\Http;
+use Illuminate\Support\Arr;
 
 /**
  * Trait Payments.
@@ -78,7 +79,7 @@ trait Payments
      */
     public function sendInvoice(array $params): Message
     {
-        $params['prices'] = json_encode(array_wrap($params['prices']));
+        $params['prices'] = json_encode(Arr::wrap($params['prices']));
         $response = $this->post('sendInvoice', $params);
 
         return new Message($response->getDecodedBody());


### PR DESCRIPTION
As this helper no longer exists in Laravel 7, it should be replaced with the `Arr::wrap` variant. I **strongly recommend** releasing a new version as this issue prevents developers from using Bot Payment API.