### PR TITLE
764-many-of-other-messengers-in-the-world-work-like-telegram-bot-api

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -40,6 +40,7 @@ class Api
 
     /** @var string The name of the environment variable that contains the Telegram Bot API Access Token. */
     const BOT_TOKEN_ENV_NAME = 'TELEGRAM_BOT_TOKEN';
+    const TELEGRAM_WEBHOOK_URL = 'TELEGRAM_WEBHOOK_URL';
 
     /**
      * Instantiates a new Telegram super-class object.
@@ -51,9 +52,10 @@ class Api
      *
      * @throws TelegramSDKException
      */
-    public function __construct($token = null, $async = false, $httpClientHandler = null)
+    public function __construct($token = null, $url = null, $async = false, $httpClientHandler = null)
     {
         $this->accessToken = $token ?? getenv(static::BOT_TOKEN_ENV_NAME);
+        $this->url = $url ?? getenv(static::TELEGRAM_WEBHOOK_URL);
         $this->validateAccessToken();
 
         if ($async) {

--- a/src/TelegramClient.php
+++ b/src/TelegramClient.php
@@ -97,7 +97,7 @@ class TelegramClient
      */
     public function prepareRequest(TelegramRequest $request): array
     {
-        $url = $this->getBaseBotUrl().$request->getAccessToken().'/'.$request->getEndpoint();
+        $url =  $this->getBaseBotUrl($request) . $request->getAccessToken() . '/' . $request->getEndpoint();
 
         return [
             $url,
@@ -112,9 +112,9 @@ class TelegramClient
      *
      * @return string
      */
-    public function getBaseBotUrl(): string
+    public function getBaseBotUrl($request): string
     {
-        return static::BASE_BOT_URL;
+        return $request->getUrl() ? $request->getUrl() : static::BASE_BOT_URL;
     }
 
     /**

--- a/src/TelegramRequest.php
+++ b/src/TelegramRequest.php
@@ -14,6 +14,9 @@ class TelegramRequest
     /** @var string|null The bot access token to use for this request. */
     protected $accessToken;
 
+    /** @var string|null The bot base url to use for this request. */
+    protected $url;
+
     /** @var string The HTTP method for this request. */
     protected $method;
 
@@ -49,12 +52,14 @@ class TelegramRequest
      */
     public function __construct(
         $accessToken = null,
+        $url = null,
         $method = null,
         $endpoint = null,
         array $params = [],
         $isAsyncRequest = false
     ) {
         $this->setAccessToken($accessToken);
+        $this->setUrl($url);
         $this->setMethod($method);
         $this->setEndpoint($endpoint);
         $this->setParams($params);
@@ -96,6 +101,16 @@ class TelegramRequest
     {
         return $this->accessToken;
     }
+    
+    /**
+     * Return the bot base url for this request.
+     *
+     * @return string|null
+     */
+    public function getUrl()
+    {
+        return $this->url;
+    }
 
     /**
      * Set the bot access token for this request.
@@ -107,6 +122,20 @@ class TelegramRequest
     public function setAccessToken(string $accessToken): self
     {
         $this->accessToken = $accessToken;
+
+        return $this;
+    }
+
+    /**
+     * Set the bot base url for this request.
+     *
+     * @param string $accessToken
+     *
+     * @return TelegramRequest
+     */
+    public function setUrl(string $url): self
+    {
+        $this->url = $url;
 
         return $this;
     }

--- a/src/Traits/Http.php
+++ b/src/Traits/Http.php
@@ -19,6 +19,9 @@ trait Http
 
     /** @var string Telegram Bot API Access Token. */
     protected $accessToken = null;
+    
+    /** @var string Telegram Bot API Base Url. */
+    protected $url = null;
 
     /** @var TelegramClient The Telegram client service. */
     protected $client = null;
@@ -87,6 +90,17 @@ trait Http
     }
 
     /**
+     * Returns Telegram Bot base Url.
+     *
+     * @return string
+     */
+
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+
+    /**
      * Sets the bot access token to use with API requests.
      *
      * @param string $accessToken The bot access token to save.
@@ -96,6 +110,21 @@ trait Http
     public function setAccessToken(string $accessToken)
     {
         $this->accessToken = $accessToken;
+
+        return $this;
+    }
+
+    /**
+     * Sets the bot url to use with API requests.
+     *
+     * @param string $url The bot base url to save.
+     *
+     * @return $this
+     */
+
+    public function setUrl(string $url)
+    {
+        $this->url = $url;
 
         return $this;
     }
@@ -318,6 +347,7 @@ trait Http
     {
         return (new TelegramRequest(
             $this->getAccessToken(),
+            $this->getUrl(),
             $method,
             $endpoint,
             $params,


### PR DESCRIPTION
https://github.com/irazasyed/telegram-bot-sdk/issues/764

as i report here

many of the messengers in another countries like this: https://devbale.ir/api

use bot api documentation like telegram

and in your good module we cant change base url from env file

so i made changes that other users can use your module as laravel module

