### PR TITLE
Added PHP 8.0 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,11 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.2, 7.3, 7.4]
+        php: ['7.2', '7.3', '7.4', '8.0']
         laravel: [5.5.*, 6.*, 7.*, '^8.0']
         dependency-version: [prefer-lowest, prefer-stable]
         exclude:
-          - php: 7.2
+          - php: '7.2'
             laravel: '^8.0'
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
@@ -72,8 +72,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "illuminate/support:${{ matrix.laravel }}" --no-interaction --no-update --no-progress --no-suggest
-          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
+          composer require "illuminate/support:${{ matrix.laravel }}" --no-interaction --no-update --no-progress --no-suggest --ignore-platform-req=php
+          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest --ignore-platform-req=php
 
       - name: Execute tests
         run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     }
   ],
   "require": {
-    "php": "^7.2",
+    "php": "^7.2 || ^8.0",
     "guzzlehttp/guzzle": "^6.3 || ^7.0.1",
     "guzzlehttp/psr7": "^1.3",
     "illuminate/support": "^5.5 || ^6.0 || ^7.0 || ^8.0",

--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -182,7 +182,7 @@ abstract class Command implements CommandInterface
         $this->entity = $entity;
         $this->arguments = $this->parseCommandArguments();
 
-        return call_user_func_array([$this, 'handle'], $this->getArguments());
+        return call_user_func_array([$this, 'handle'], array_keys($this->getArguments()));
     }
 
     /**

--- a/src/Helpers/Emojify.php
+++ b/src/Helpers/Emojify.php
@@ -218,22 +218,24 @@ class Emojify
     }
 
     /**
-     * Private clone method to prevent cloning of the instance of the
-     * *Singleton* instance.
+     * Throw an exception when the user tries to clone the *Singleton*
+     * instance.
      *
-     * @return void
+     * @throws \LogicException always
      */
-    private function __clone()
+    public function __clone()
     {
+        throw new \LogicException('The Emojify helper cannot be cloned');
     }
 
     /**
-     * Private unserialize method to prevent unserializing of the *Singleton*
+     * Throw an exception when the user tries to unserialize the *Singleton*
      * instance.
      *
-     * @return void
+     * @throws \LogicException always
      */
-    private function __wakeup()
+    public function __wakeup()
     {
+        throw new \LogicException('The Emojify helper cannot be serialised');
     }
 }

--- a/src/Traits/Singleton.php
+++ b/src/Traits/Singleton.php
@@ -32,23 +32,25 @@ trait Singleton
     }
 
     /**
-     * Private clone method to prevent cloning of the instance of the
-     * Singleton instance.
+     * Throw an exception when the user tries to clone the *Singleton*
+     * instance.
      *
-     * @return void
+     * @throws \LogicException always
      */
-    private function __clone()
+    public function __clone()
     {
+        throw new \LogicException('This Singleton cannot be cloned');
     }
 
     /**
-     * Private unserialize method to prevent unserializing of the Singleton
+     * Throw an exception when the user tries to unserialize the *Singleton*
      * instance.
      *
-     * @return void
+     * @throws \LogicException always
      */
-    private function __wakeup()
+    public function __wakeup()
     {
+        throw new \LogicException('This Singleton cannot be serialised');
     }
 
     public static function destroy()


### PR DESCRIPTION
Added PHP 8.0 support to Composer and GitHub Actions matrix

Some logic needed to be changed:

1. Singletons had `private function __clone` and `private function __wakeup`. I replaced these to throw `LogicExceptions` ("Errors that should lead to a fix in your code")
2. `call_user_func_array` was changed in PHP 8.0 to accept an associative array as named arguments. Wrapping them in `array_values` solves this issue.
3. Added `--ignore-platform-req=php` to GitHub actions, to allow testing old code on new PHP versions.