### PR TITLE
Added Laravel 8.0 to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,11 @@ jobs:
       fail-fast: true
       matrix:
         php: [7.2, 7.3, 7.4]
-        laravel: [5.5.*, 6.*, 7.*]
+        laravel: [5.5.*, 6.*, 7.*, '^8.0']
         dependency-version: [prefer-lowest, prefer-stable]
+        exclude:
+          - php: 7.2
+            laravel: '^8.0'
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
     env:


### PR DESCRIPTION
I added Laravel 8.0 to the CI, but with an exception on PHP 7.2 (since it's not
supported by Laravel 8.0).

I also used the semver notation (`^8.0`) instead of the wildcard notation
(`8.*`) since Laravel has been Semver since 6.0.
