### PR TITLE
Fixed commands receiving argument names instead of values

### DIFF
--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -182,7 +182,7 @@ abstract class Command implements CommandInterface
         $this->entity = $entity;
         $this->arguments = $this->parseCommandArguments();
 
-        return call_user_func_array([$this, 'handle'], array_keys($this->getArguments()));
+        return call_user_func_array([$this, 'handle'], array_values($this->getArguments()));
     }
 
     /**


### PR DESCRIPTION
As reported [here](https://github.com/irazasyed/telegram-bot-sdk/commit/84a3574aad6c677768b0d3354e054d863ef80f62#commitcomment-44974105).
