### PR TITLE
Fix an error in validateInputFileField

### DIFF
--- a/src/Traits/Http.php
+++ b/src/Traits/Http.php
@@ -340,7 +340,7 @@ trait Http
         }
 
         // All file-paths, urls, or file resources should be provided by using the InputFile object
-        if ((! $params[$inputFileField] instanceof InputFile) || (is_string($params[$inputFileField]) && ! $this->is_json($params[$inputFileField]))) {
+        if ((! $params[$inputFileField] instanceof InputFile) && (is_string($params[$inputFileField]) && ! $this->is_json($params[$inputFileField]))) {
             throw CouldNotUploadInputFile::inputFileParameterShouldBeInputFileEntity($inputFileField);
         }
     }


### PR DESCRIPTION
Found a logical error while tried to send image URLs with `sendMediaGroup` 
Also, maybe a good idea to move `is_string` into `is_json` 