### PR TITLE
Update Http.php, Because of array to string conversion in Laravel 8

### DIFF
--- a/src/Traits/Http.php
+++ b/src/Traits/Http.php
@@ -204,6 +204,10 @@ trait Http
      * @param array $params
      *
      * @return array
+     *
+     * If your laravel version is below 7
+     *
+     * You could use (string)$params['reply_markup'] instead of json_encode($params['reply_markup']) 
      */
     protected function replyMarkupToString(array $params): array
     {

--- a/src/Traits/Http.php
+++ b/src/Traits/Http.php
@@ -208,7 +208,7 @@ trait Http
     protected function replyMarkupToString(array $params): array
     {
         if (isset($params['reply_markup'])) {
-            $params['reply_markup'] = (string) $params['reply_markup'];
+            $params['reply_markup'] = json_encode($params['reply_markup']);
         }
 
         return $params;


### PR DESCRIPTION
Because of an error that I occurred with ```(string)array``` in Laravel 8, I changed this line to ```json_encode``` to solve this problem.