### PR TITLE
Fixed: method ReflectionParameter::getClass() is deprecated, PHP8

### DIFF
--- a/src/Answers/AnswerBus.php
+++ b/src/Answers/AnswerBus.php
@@ -57,7 +57,12 @@ abstract class AnswerBus
         $container = $this->telegram->getContainer();
         $dependencies = [];
         foreach ($params as $param) {
-            $dependencies[] = $container->make($param->getClass()->name);
+            if (version_compare(PHP_VERSION, '8.0.0') >= 0) {
+                $dependencies[] = $container->make($param->getType()->getName());
+            }
+            else{
+                $dependencies[] = $container-make($param->getClass()->name);
+            }
         }
 
         // and instantiate the object with dependencies through ReflectionClass


### PR DESCRIPTION
If the `PHP version >= 8.0.0` then `getType()` method will be used else keep the previous method.