### PR TITLE
Fix: Aliased command not received arguments

### DIFF
--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -271,7 +271,14 @@ abstract class Command implements CommandInterface
             })
             ->implode('');
 
-        return "%/{$this->getName()}{$optionalBotName}{$required}{$optional}{$customRegex}%si";
+        if (empty($this->getAliases())) {
+            $commandName = $this->getName();
+        } else {
+            $names = array_merge([$this->getName()], $this->getAliases());
+            $commandName = '(?:' . implode('|', $names) . ')';
+        }
+
+        return "%/{$commandName}{$optionalBotName}{$required}{$optional}{$customRegex}%si";
     }
 
     private function formatMatches(array $matches, Collection $required, Collection $optional)


### PR DESCRIPTION
I've the same issue with #837 that using alias command not received arguments.

After checking, it turns out that the problem is in the regex in the prepareRegex function in the Telegram\Bot\Commands\Command class.

Example:
```
class ExampleCommand extends Command
{
    protected $name = 'example';
    protected $aliases = ['e'];
    protected $pattern = '{code}';
}
```

`/example text`
> `%/example(?:@.+?bot)?\s+?(?P<code>[^ ]++)%si`

`/e text`
> `%/example(?:@.+?bot)?\s+?(?P<code>[^ ]++)%si`

as you can see, the regex use command name instead of the alias name