### PR TITLE
Added ability to use custom command processors.

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -4,6 +4,7 @@ namespace Telegram\Bot;
 
 use BadMethodCallException;
 use Illuminate\Support\Traits\Macroable;
+use Telegram\Bot\Commands\CommandBus;
 use Telegram\Bot\Exceptions\TelegramSDKException;
 use Telegram\Bot\HttpClients\HttpClientInterface;
 
@@ -45,14 +46,18 @@ class Api
      * Instantiates a new Telegram super-class object.
      *
      *
+     * @param CommandBus               $commandBus        The Telegram Bot API Access Token.
      * @param string                   $token             The Telegram Bot API Access Token.
      * @param bool                     $async             (Optional) Indicates if the request to Telegram will be asynchronous (non-blocking).
      * @param HttpClientInterface|null $httpClientHandler (Optional) Custom HTTP Client Handler.
      *
      * @throws TelegramSDKException
      */
-    public function __construct($token = null, $async = false, $httpClientHandler = null)
+    public function __construct(CommandBus $commandBus, $token = null, $async = false, $httpClientHandler = null)
     {
+        $commandBus->setTelegram($this);
+        $this->commandBus = $commandBus;
+
         $this->accessToken = $token ?? getenv(static::BOT_TOKEN_ENV_NAME);
         $this->validateAccessToken();
 

--- a/src/Commands/BotCommandsProcessor.php
+++ b/src/Commands/BotCommandsProcessor.php
@@ -28,7 +28,7 @@ class BotCommandsProcessor implements CommandsProcessor
                 })->all();
         }
 
-        return [];
+        return ['help' => []];
     }
 
     /**

--- a/src/Commands/BotCommandsProcessor.php
+++ b/src/Commands/BotCommandsProcessor.php
@@ -28,7 +28,7 @@ class BotCommandsProcessor implements CommandsProcessor
                 })->all();
         }
 
-        return ['help' => []];
+        return [];
     }
 
     /**

--- a/src/Commands/BotCommandsProcessor.php
+++ b/src/Commands/BotCommandsProcessor.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+namespace Telegram\Bot\Commands;
+
+use Illuminate\Support\Collection;
+use Telegram\Bot\Objects\Update;
+
+class BotCommandsProcessor implements CommandsProcessor
+{
+    public function handle(Update $update): array
+    {
+        $parser = new CommandParser();
+
+        $message = $update->getMessage();
+
+        if ($message->has('entities')) {
+            return $this->parseCommandsIn($message)
+                ->mapWithKeys(function (array $entity) use ($parser, $update) {
+
+                    $command = $parser->parse(
+                        $update->getMessage()->text,
+                        $entity['offset'],
+                        $entity['length']
+                    );
+
+                    return [$command => $entity];
+                })->all();
+        }
+
+        return [];
+    }
+
+    /**
+     * Returns all bot_commands detected in the update.
+     *
+     * @param Collection $message
+     * @return Collection
+     */
+    protected function parseCommandsIn(Collection $message): Collection
+    {
+        return collect($message->get('entities'))
+            ->filter(function ($entity) {
+                return $entity['type'] === 'bot_command';
+            });
+    }
+}

--- a/src/Commands/CommandBus.php
+++ b/src/Commands/CommandBus.php
@@ -169,6 +169,7 @@ class CommandBus extends AnswerBus
 
         $command = $this->commands[$name] ??
             $this->commandAliases[$name] ??
+            $this->commands['help'] ??
             collect($this->commands)->filter(function ($command) use ($name) {
                 return $command instanceof $name;
             })->first() ?? null;

--- a/src/Commands/CommandBus.php
+++ b/src/Commands/CommandBus.php
@@ -13,8 +13,6 @@ use Telegram\Bot\Traits\Singleton;
  */
 class CommandBus extends AnswerBus
 {
-    use Singleton;
-
     /** @var Command[] Holds all commands. */
     protected $commands = [];
 

--- a/src/Commands/CommandParser.php
+++ b/src/Commands/CommandParser.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+namespace Telegram\Bot\Commands;
+
+use Illuminate\Support\Str;
+use InvalidArgumentException;
+
+class CommandParser
+{
+    /**
+     * Parse a Command for a Match.
+     *
+     * @param string $text
+     * @param int $offset
+     * @param int $length
+     *
+     * @return string
+     */
+    public function parse(string $text, int $offset, int $length): string
+    {
+        if (trim($text) === '') {
+            throw new InvalidArgumentException('Message is empty, Cannot parse for command');
+        }
+
+        $command = substr(
+            $text,
+            $offset + 1,
+            $length - 1
+        );
+
+        // When in group - Ex: /command@MyBot
+        if (Str::contains($command, '@') && Str::endsWith($command, ['bot', 'Bot'])) {
+            $command = explode('@', $command);
+            $command = $command[0];
+        }
+
+        return $command;
+    }
+}

--- a/src/Commands/CommandsProcessor.php
+++ b/src/Commands/CommandsProcessor.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Telegram\Bot\Commands;
+
+use Telegram\Bot\Objects\Update;
+
+interface CommandsProcessor
+{
+    /**
+     * Handle bot message
+     *
+     * @param Update $update
+     * @return CommandInterface[]|array Commands that match to given message
+     */
+    public function handle(Update $update): array;
+}

--- a/src/Laravel/TelegramServiceProvider.php
+++ b/src/Laravel/TelegramServiceProvider.php
@@ -61,9 +61,9 @@ class TelegramServiceProvider extends ServiceProvider
 
             $processors = (array)config('telegram.command_processors', [BotCommandsProcessor::class]);
 
-            $processors = array_map(function ($processor) {
+            $processors = array_map(function ($processor) use ($app) {
                 if (is_string($processor)) {
-                    return $this->app->make($processor);
+                    $processor = $app->make($processor);
                 }
 
                 if ($processor instanceof CommandsProcessor) {

--- a/src/Laravel/config/telegram.php
+++ b/src/Laravel/config/telegram.php
@@ -201,4 +201,16 @@ return [
         // 'stop' => Acme\Project\Commands\StopCommand::class,
         // 'status' => Acme\Project\Commands\StatusCommand::class,
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Processors to handle commands
+    |--------------------------------------------------------------------------
+    |
+    | Processors let you match commands with telegram messages by your own rules.
+    |
+    */
+    'command_processors'           => [
+        \Telegram\Bot\Commands\BotCommandsProcessor::class
+    ]
 ];

--- a/src/Traits/CommandsHandler.php
+++ b/src/Traits/CommandsHandler.php
@@ -10,6 +10,9 @@ use Telegram\Bot\Commands\CommandBus;
  */
 trait CommandsHandler
 {
+    /** @var CommandBus */
+    protected $commandBus;
+
     /**
      * Return Command Bus.
      *
@@ -17,7 +20,7 @@ trait CommandsHandler
      */
     protected function getCommandBus(): CommandBus
     {
-        return CommandBus::Instance()->setTelegram($this);
+        return $this->commandBus;
     }
 
     /**

--- a/tests/Integration/BotsManagerTest.php
+++ b/tests/Integration/BotsManagerTest.php
@@ -3,8 +3,8 @@
 namespace Telegram\Bot\Tests\Integration;
 
 use InvalidArgumentException;
-use PHPUnit\Framework\TestCase;
 use Telegram\Bot\BotsManager;
+use Telegram\Bot\Tests\TestCase;
 
 class BotsManagerTest extends TestCase
 {
@@ -17,6 +17,7 @@ class BotsManagerTest extends TestCase
     {
         parent::setUp();
         $this->manager = new BotsManager(
+            $this->mockCommandBus(),
             [
                 'default'                      => 'bot1',
                 'bots'                         => [
@@ -47,7 +48,7 @@ class BotsManagerTest extends TestCase
     /** @test a bots manager can be created */
     public function a_bots_manager_can_be_created_with_no_config()
     {
-        $manager = new BotsManager([]);
+        $manager = new BotsManager($this->mockCommandBus(), []);
 
         $this->assertInstanceOf(BotsManager::class, $manager);
     }
@@ -59,14 +60,14 @@ class BotsManagerTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        $manager = new BotsManager([]);
+        $manager = new BotsManager($this->mockCommandBus(), []);
         $manager->bot('demo');
     }
 
     /** @test an invalid config paramters returns null */
     public function an_invalid_or_missing_config_parameter_returns_null()
     {
-        $manager = new BotsManager([]);
+        $manager = new BotsManager($this->mockCommandBus(), []);
 
         $name = $manager->getDefaultBotName();
 
@@ -106,6 +107,7 @@ class BotsManagerTest extends TestCase
     public function duplicated_commands_dont_cause_a_problem()
     {
         $manager = new BotsManager(
+            $this->mockCommandBus(),
             [
                 'commands'        => [
                     'Acme\Project\Commands\Command1',

--- a/tests/Integration/TelegramApiTest.php
+++ b/tests/Integration/TelegramApiTest.php
@@ -6,7 +6,7 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Stream;
 use function GuzzleHttp\Psr7\stream_for;
 use League\Event\Emitter;
-use PHPUnit\Framework\TestCase;
+use Telegram\Bot\Tests\TestCase;
 use Prophecy\Argument;
 use Telegram\Bot\Api;
 use Telegram\Bot\Commands\CommandBus;
@@ -43,7 +43,7 @@ class TelegramApiTest extends TestCase
      */
     protected function getApi($client = null, $token = 'TELEGRAM_TOKEN', $async = false)
     {
-        return new Api($token, $async, $client);
+        return new Api(new CommandBus([]), $token, $async, $client);
     }
 
     /**

--- a/tests/Integration/TelegramApiTest.php
+++ b/tests/Integration/TelegramApiTest.php
@@ -26,13 +26,6 @@ class TelegramApiTest extends TestCase
 {
     use GuzzleMock, CommandGenerator;
 
-    protected function tearDown(): void
-    {
-        // Prevent previous commands added to the bus lingering between
-        // tests.
-        CommandBus::destroy();
-    }
-
     /**
      * @param  GuzzleHttpClient|null  $client
      * @param  string                 $token

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace Telegram\Bot\Tests;
+
+use Telegram\Bot\Commands\CommandBus;
+
+class TestCase extends \PHPUnit\Framework\TestCase
+{
+    public function mockCommandBus()
+    {
+        return $this->createMock(CommandBus::class);
+    }
+}

--- a/tests/Unit/Commands/BotCommandsProcessorTest.php
+++ b/tests/Unit/Commands/BotCommandsProcessorTest.php
@@ -1,0 +1,69 @@
+<?php
+declare(strict_types=1);
+
+namespace Telegram\Bot\Tests\Unit\Commands;
+
+use Telegram\Bot\Commands\BotCommandsProcessor;
+use Telegram\Bot\Objects\Update;
+use Telegram\Bot\Tests\TestCase;
+
+class BotCommandsProcessorTest extends TestCase
+{
+    /** @var BotCommandsProcessor */
+    private $processor;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->processor = new BotCommandsProcessor();
+    }
+
+    /** @test */
+    public function it_bot_command_should_return_parsed_data()
+    {
+        $update = new Update([
+            'message' => [
+                'text'     => 'This /demo',
+                'entities' => [
+                    [
+                        'type'   => 'bot_command',
+                        'offset' => 5,
+                        'length' => 5,
+                    ],
+                ],
+            ],
+        ]);
+
+        $results = $this->processor->handle($update);
+
+        $this->assertEquals([
+            'demo' => [
+                'type'   => 'bot_command',
+                'offset' => 5,
+                'length' => 5,
+            ]
+        ], $results);
+    }
+
+    /** @test */
+    public function it_not_a_bot_command_should_return_empty_array()
+    {
+        $update = new Update([
+            'message' => [
+                'text'     => 'This demo',
+                'entities' => [
+                    [
+                        'type'   => 'not_bot_command',
+                        'offset' => 5,
+                        'length' => 5,
+                    ],
+                ],
+            ],
+        ]);
+
+        $results = $this->processor->handle($update);
+
+        $this->assertEquals([], $results);
+    }
+}

--- a/tests/Unit/Commands/CommandParserTest.php
+++ b/tests/Unit/Commands/CommandParserTest.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+namespace Telegram\Bot\Tests\Unit\Commands;
+
+use Telegram\Bot\Commands\CommandParser;
+use Telegram\Bot\Tests\TestCase;
+
+class CommandParserTest extends TestCase
+{
+    /** @var CommandParser */
+    private $parser;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        
+        $this->parser = new CommandParser();
+    }
+
+    /** @test */
+    public function it_can_return_the_command_name_from_a_message_correctly_ignoring_the_slash()
+    {
+        $message01 = 'The command is /demo and is in the middle of the string.';
+        $message02 = '/beginning command is at the start of a string.';
+
+        $commandName01 = $this->parser->parse($message01, 15, 5);
+        $commandName02 = $this->parser->parse($message02, 0, 10);
+
+        $this->assertEquals('demo', $commandName01);
+        $this->assertEquals('beginning', $commandName02);
+    }
+
+    /** @test */
+    public function it_can_parse_a_command_from_a_group_of_bots()
+    {
+        $message01 = 'The command is /demo@MyDemo_Bot and is in the middle of the string.';
+        $message02 = '/demo@MyDemo_Bot command is at the start of a string.';
+
+        $commandName01 = $this->parser->parse($message01, 15, 16);
+        $commandName02 = $this->parser->parse($message02, 0, 16);
+
+        $this->assertEquals('demo', $commandName01);
+        $this->assertEquals('demo', $commandName02);
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_an_exception_if_parsing_for_a_command_in_a_message_with_no_text()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $message = '';
+
+        $this->parser->parse($message, 5, 5);
+    }
+}

--- a/tests/Unit/Commands/CommandTest.php
+++ b/tests/Unit/Commands/CommandTest.php
@@ -2,7 +2,7 @@
 
 namespace Telegram\Bot\Tests\Unit\Commands;
 
-use PHPUnit\Framework\TestCase;
+use Telegram\Bot\Tests\TestCase;
 use Telegram\Bot\Api;
 use Telegram\Bot\Commands\Command;
 use Telegram\Bot\Objects\Update;

--- a/tests/Unit/Commands/HelpCommandTest.php
+++ b/tests/Unit/Commands/HelpCommandTest.php
@@ -2,7 +2,7 @@
 
 namespace Telegram\Bot\Tests\Unit\Commands;
 
-use PHPUnit\Framework\TestCase;
+use Telegram\Bot\Tests\TestCase;
 use Prophecy\Argument;
 use Telegram\Bot\Api;
 use Telegram\Bot\Commands\HelpCommand;

--- a/tests/Unit/FileUpload/InputFileTest.php
+++ b/tests/Unit/FileUpload/InputFileTest.php
@@ -3,7 +3,7 @@
 namespace Telegram\Bot\Tests\Unit\FileUpload;
 
 use GuzzleHttp\Psr7\LazyOpenStream;
-use PHPUnit\Framework\TestCase;
+use Telegram\Bot\Tests\TestCase;
 use Telegram\Bot\FileUpload\InputFile;
 
 class InputFileTest extends TestCase

--- a/tests/Unit/Methods/UpdateTest.php
+++ b/tests/Unit/Methods/UpdateTest.php
@@ -2,7 +2,7 @@
 
 namespace Telegram\Bot\Tests\Unit\Methods;
 
-use PHPUnit\Framework\TestCase;
+use Telegram\Bot\Tests\TestCase;
 use Telegram\Bot\Exceptions\TelegramSDKException;
 use Telegram\Bot\Methods\Update;
 

--- a/tests/Unit/Traits/ValidatorTest.php
+++ b/tests/Unit/Traits/ValidatorTest.php
@@ -2,7 +2,7 @@
 
 namespace Telegram\Bot\Tests\Unit\Traits;
 
-use PHPUnit\Framework\TestCase;
+use Telegram\Bot\Tests\TestCase;
 use Telegram\Bot\Traits\Validator;
 
 class ValidatorTest extends TestCase


### PR DESCRIPTION
There was only one way to match command with telegram message via CommandBus and it was hardcoded.

I separated command matching logic with command bus and now users can create their own processors and combine them.

Processors can be set in config file.

**For example**

Let's imagine that we have a command for storing tweets from telegram bot in database. And we want to send just tweet url without command `/handle_tweet ....`, only url.

```php
class TweetHandlerCommand extends Command {
     protected $name = 'handle_tweet';

     public function handle() 
     {
          // store tweet in database
          return true;
     }
}

```
And we can create processor, that will listen to telegram bot messages and match them with regex and route to `TweetHandlerCommand`

```php
use Telegram\Bot\Commands\CommandsProcessor;

class TweetCommandProcessor  implements CommandsProcessor {
    private const REGEX = '#https?://twitter\.com/(?:\#!/)?(?<username>\w+)/status(es)?/(?<id>\d+)#is';

    public function handle(Update $update): array
    {
        $message = $update->getMessage();

        if ($message->has('entities')) {
            return collect($message->get('entities'))
                ->filter(unction (array $entity) { return preg_match(self::REGEX, $message->text, $match) !== 1})
                ->mapWithKeys(function (array $entity) use ($parser, $update) {
                    return ['handle_tweet' => $entity];
                })->all();
        }

        return [];
    }
}
```

or

```php

use Telegram\Bot\Answers\Answerable;
use Telegram\Bot\Api;
use Telegram\Bot\Commands\CommandsProcessor;

class TweetCommandProcessor  implements CommandsProcessor {
    use Answerable;

    private const REGEX = '#https?://twitter\.com/(?:\#!/)?(?<username>\w+)/status(es)?/(?<id>\d+)#is';

    public function handle(Update $update): array
    {
        $message = $update->getMessage();

        if ($message->has('entities')) {
            return collect($message->get('entities'))
                ->filter(unction (array $entity) { return preg_match(self::REGEX, $message->text, $match) !== 1})
                ->map(function (array $entity) use ($update) {
                    return function(Api $telegram, Update $update) {
                           $this->setTelegram($telegram);
                           $this->update = $update;

                           // Store tweet in database 
                           $this->replyWithMessage([
                                'text' => 'Tweet stored in database',
                          ]);

                           return true;
                    };
                })->all();
        }

        return [];
    }
}
```

or maybe you want to log messages

```php
use Telegram\Bot\Commands\CommandsProcessor;

class LogMessagesCommandProcessor  implements CommandsProcessor {

    public function handle(Update $update): array
    {
        $message = $update->getMessage();


        return [function(Api $telegram, Update $update) use($message) {
                 logger()->debug('new tweet', [
                     'text' => $message->text
                 ]);
       }];
    }
}
```

I think it will be a good feature for your v3.x