### PR TITLE
Support upload file via URL

### DIFF
--- a/src/Traits/Http.php
+++ b/src/Traits/Http.php
@@ -233,7 +233,7 @@ trait Http
             throw CouldNotUploadInputFile::missingParam($inputFileField);
         }
 
-        if ($this->hasFileId($inputFileField, $params)) {
+        if ($this->hasFileId($inputFileField, $params) || $this->hasUrl($inputFileField, $params)) {
             return $this->post($endpoint, $params);
         }
 

--- a/src/Traits/Validator.php
+++ b/src/Traits/Validator.php
@@ -20,6 +20,19 @@ trait Validator
     protected function hasFileId(string $inputFileField, array $params): bool
     {
         return isset($params[$inputFileField]) && $this->isFileId($params[$inputFileField]);
+	}
+
+    /**
+     * Determine given param in params array is a URL.
+     *
+     * @param string $inputFileField
+     * @param array  $params
+     *
+     * @return bool
+     */
+    protected function hasUrl(string $inputFileField, array $params): bool
+    {
+        return isset($params[$inputFileField]) && $this->isUrl($params[$inputFileField]);
     }
 
     /**


### PR DESCRIPTION
Upload files via URL can benefit from CDN and Telegram cache and most methods support it. It could be much faster when sending the same file more than once.

Hope this library can support it too!

Ref: [Telegram Bot API Manual > Sending Files](https://core.telegram.org/bots/api#sending-files), issue #42, issue #206, issue #394.