### PR TITLE
add deleteMessage method

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -307,6 +307,32 @@ class Api
     }
 
     /**
+     * Delete message
+     *
+     * <code>
+     * $params = [
+     *   'chat_id'                  => '',
+     *   'message_id'               => '',
+     * ];
+     * </code>
+     *
+     * @link https://core.telegram.org/bots/api#sendmessage
+     *
+     * @param  array  $params
+     *
+     * @var int|string $params ['chat_id']
+     * @var int $params ['message_id']
+     *
+     * @return Message
+     */
+    public function deleteMessage(array $params)
+    {
+        $response = $this->post('sendMessage', $params);
+
+        return new Message($response->getDecodedBody());
+    }
+
+    /**
      * Forward messages of any kind.
      *
      * <code>


### PR DESCRIPTION
Use this method to delete a message, including service messages, with the following limitations:
- A message can only be deleted if it was sent less than 48 hours ago.
- A dice message in a private chat can only be deleted if it was sent more than 24 hours ago.
- Bots can delete outgoing messages in private chats, groups, and supergroups.
- Bots can delete incoming messages in private chats.
- Bots granted can_post_messages permissions can delete outgoing messages in channels.
- If the bot is an administrator of a group, it can delete any message there.
- If the bot has can_delete_messages permission in a supergroup or a channel, it can delete any message there.
Returns True on success.