### PR TITLE
Handle all possible Guzzle request exceptions

### DIFF
--- a/src/HttpClients/GuzzleHttpClient.php
+++ b/src/HttpClients/GuzzleHttpClient.php
@@ -4,10 +4,12 @@ namespace Telegram\Bot\HttpClients;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Promise;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\RequestOptions;
+use Psr\Http\Client\RequestExceptionInterface;
 use Psr\Http\Message\ResponseInterface;
 use Telegram\Bot\Exceptions\TelegramSDKException;
 use Throwable;
@@ -84,11 +86,14 @@ class GuzzleHttpClient implements HttpClientInterface
             } else {
                 $response = $response->wait();
             }
-        } catch (RequestException $e) {
-            $response = $e->getResponse();
+        } catch (GuzzleException $e) {
+            $response = null;
+            if ($e instanceof RequestExceptionInterface || $e instanceof RequestException) {
+                $response = $e->getResponse();
+            }
 
             if (! $response instanceof ResponseInterface) {
-                throw new TelegramSDKException($e->getMessage(), $e->getCode());
+                throw new TelegramSDKException($e->getMessage(), $e->getCode(), $e);
             }
         }
 


### PR DESCRIPTION
`RequestException` is just a subset of possible exceptions thrown while performing the request.
For example, connection failure leads to `ConnectException` and so on.

The best way is to catch all `GuzzleException` instances and wrap them in `TelegramSDKException`.

Also, I added the original exception as an argument to `TelegramSDKException` so it can be retrieved in the app later.