### PR TITLE
Fixed conflict command aliases

### DIFF
--- a/src/Laravel/TelegramServiceProvider.php
+++ b/src/Laravel/TelegramServiceProvider.php
@@ -54,7 +54,7 @@ class TelegramServiceProvider extends ServiceProvider
      */
     protected function registerBindings()
     {
-        $this->app->bind(BotsManager::class, static function ($app) {
+        $this->app->singleton(BotsManager::class, static function ($app) {
             return (new BotsManager(config('telegram')))->setContainer($app);
         });
         $this->app->alias(BotsManager::class, 'telegram');


### PR DESCRIPTION
This problem occurs when we have multiple instances of the bot manager.
The bot manager initializes the bot each time and registers its commands (command bus - singleton).