### PR TITLE
Psr7 v2 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   "require": {
     "php": "^7.2 || ^8.0",
     "guzzlehttp/guzzle": "^6.3 || ^7.0.1",
-    "guzzlehttp/psr7": "^1.4",
+    "guzzlehttp/psr7": "^1.4 || ^2",
     "illuminate/support": "^5.5 || ^6.0 || ^7.0 || ^8.0",
     "league/event": "^2.1"
   },

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   "require": {
     "php": "^7.2 || ^8.0",
     "guzzlehttp/guzzle": "^6.3 || ^7.0.1",
-    "guzzlehttp/psr7": "^1.3",
+    "guzzlehttp/psr7": "^1.4",
     "illuminate/support": "^5.5 || ^6.0 || ^7.0 || ^8.0",
     "league/event": "^2.1"
   },


### PR DESCRIPTION
1. Fix `composer.json` require config: guzzle 6.3.0 is not support psr7 1.3.0 (need up to 1.4)
2. Add unit tests to compatible with psr7 2 and leave backward compatibility with 1.4.0
3. Add Psr7 v2 support