### PR TITLE
Add support for RequestInterface for webhooks

### DIFF
--- a/src/Methods/Update.php
+++ b/src/Methods/Update.php
@@ -2,6 +2,7 @@
 
 namespace Telegram\Bot\Methods;
 
+use Psr\Http\Message\RequestInterface;
 use Telegram\Bot\Events\UpdateWasReceived;
 use Telegram\Bot\Exceptions\TelegramSDKException;
 use Telegram\Bot\FileUpload\InputFile;
@@ -149,15 +150,15 @@ trait Update
      * Returns a webhook update sent by Telegram.
      * Works only if you set a webhook.
      *
+     * @param bool $shouldEmitEvent
+     * @param RequestInterface|null $request
+     * @return UpdateObject
      * @see setWebhook
      *
-     * @param bool $shouldEmitEvent
-     *
-     * @return UpdateObject
      */
-    public function getWebhookUpdate($shouldEmitEvent = true): UpdateObject
+    public function getWebhookUpdate($shouldEmitEvent = true, ?RequestInterface $request = null): UpdateObject
     {
-        $body = json_decode(file_get_contents('php://input'), true);
+        $body = $this->getRequestBody($request);
 
         $update = new UpdateObject($body);
 
@@ -203,5 +204,20 @@ trait Update
         }
 
         return InputFile::create($certificate, 'certificate.pem');
+    }
+
+    /**
+     * @param RequestInterface|null $request
+     * @return mixed
+     */
+    private function getRequestBody(?RequestInterface $request)
+    {
+        if ($request instanceof RequestInterface) {
+            $rawBody = (string) $request->getBody();
+        } else {
+            $rawBody = file_get_contents('php://input');
+        }
+
+        return json_decode($rawBody, true);
     }
 }

--- a/src/Traits/CommandsHandler.php
+++ b/src/Traits/CommandsHandler.php
@@ -2,6 +2,7 @@
 
 namespace Telegram\Bot\Traits;
 
+use Psr\Http\Message\RequestInterface;
 use Telegram\Bot\Objects\Update;
 use Telegram\Bot\Commands\CommandBus;
 
@@ -34,22 +35,23 @@ trait CommandsHandler
      * Processes Inbound Commands.
      *
      * @param bool $webhook
-     *
+     * @param RequestInterface|null $request
      * @return Update|Update[]
      */
-    public function commandsHandler(bool $webhook = false)
+    public function commandsHandler(bool $webhook = false, ?RequestInterface $request = null)
     {
-        return $webhook ? $this->useWebHook() : $this->useGetUpdates();
+        return $webhook ? $this->useWebHook($request) : $this->useGetUpdates();
     }
 
     /**
      * Process the update object for a command from your webhook.
      *
+     * @param RequestInterface|null $request
      * @return Update
      */
-    protected function useWebHook(): Update
+    protected function useWebHook(?RequestInterface $request = null): Update
     {
-        $update = $this->getWebhookUpdate();
+        $update = $this->getWebhookUpdate(true, $request);
         $this->processCommand($update);
 
         return $update;


### PR DESCRIPTION
Raw request body cannot be read from `php://input` when using webhook and swoole+laravel.
RequestInterface should be passed as parameter in order to acces to Telegram data.

P.s Laravel `Request` class isn't PSR standard, you must install [some packages](https://laravel.com/docs/8.x/requests#psr7-requests) and inject `ServerRequestInterface`