### PR TITLE
Fix `is not valid header value`

### DIFF
--- a/src/TelegramRequest.php
+++ b/src/TelegramRequest.php
@@ -185,7 +185,7 @@ class TelegramRequest
     public function getDefaultHeaders(): array
     {
         return [
-            'User-Agent' => 'Telegram Bot PHP SDK v'.Api::VERSION.' - (https://github.com/irazasyed/telegram-bot-sdk)',
+            'User-Agent' => 'Telegram Bot PHP SDK v'.Api::VERSION.' (https://github.com/irazasyed/telegram-bot-sdk)',
         ];
     }
 


### PR DESCRIPTION
Fix for https://github.com/irazasyed/telegram-bot-sdk/issues/933