### PR TITLE
Add some useful exceptions

### DIFF
--- a/src/Exceptions/TelegramRateLimitedException.php
+++ b/src/Exceptions/TelegramRateLimitedException.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Telegram\Bot\Exceptions;
+
+use Throwable;
+
+class TelegramRateLimitedException extends TelegramSDKException
+{
+    /**
+     * Throttled time value
+     *
+     * @var int
+     */
+    private $value;
+
+    public function __construct($message, int $value, $code = 429, Throwable $previous = null)
+    {
+        $this->setValue($value);
+
+        parent::__construct($message, $code, $previous);
+    }
+
+    /**
+     * @return int
+     */
+    public function getValue(): int
+    {
+        return $this->value;
+    }
+
+    /**
+     * @param int $value
+     */
+    public function setValue(int $value): void
+    {
+        $this->value = $value;
+    }
+}

--- a/src/Exceptions/TelegramRateLimitedException.php
+++ b/src/Exceptions/TelegramRateLimitedException.php
@@ -7,7 +7,7 @@ use Throwable;
 class TelegramRateLimitedException extends TelegramSDKException
 {
     /**
-     * Throttled time value
+     * Threshold time value
      *
      * @var int
      */
@@ -15,7 +15,7 @@ class TelegramRateLimitedException extends TelegramSDKException
 
     public function __construct($message, int $value, $code = 429, Throwable $previous = null)
     {
-        $this->setValue($value);
+        $this->setThresholdValue($value);
 
         parent::__construct($message, $code, $previous);
     }
@@ -23,7 +23,7 @@ class TelegramRateLimitedException extends TelegramSDKException
     /**
      * @return int
      */
-    public function getValue(): int
+    public function getThresholdValue(): int
     {
         return $this->value;
     }
@@ -31,7 +31,7 @@ class TelegramRateLimitedException extends TelegramSDKException
     /**
      * @param int $value
      */
-    public function setValue(int $value): void
+    public function setThresholdValue(int $value): void
     {
         $this->value = $value;
     }

--- a/src/Exceptions/TelegramRateLimitedException.php
+++ b/src/Exceptions/TelegramRateLimitedException.php
@@ -7,7 +7,7 @@ use Throwable;
 class TelegramRateLimitedException extends TelegramSDKException
 {
     /**
-     * Threshold time value
+     * Threshold value
      *
      * @var int
      */

--- a/src/Exceptions/TelegramUserBlockedException.php
+++ b/src/Exceptions/TelegramUserBlockedException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Telegram\Bot\Exceptions;
+
+class TelegramUserBlockedException extends TelegramSDKException
+{
+
+}

--- a/src/Exceptions/TelegramUserDeactivatedException.php
+++ b/src/Exceptions/TelegramUserDeactivatedException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Telegram\Bot\Exceptions;
+
+class TelegramUserDeactivatedException extends TelegramSDKException
+{
+
+}

--- a/src/HttpClients/GuzzleHttpClient.php
+++ b/src/HttpClients/GuzzleHttpClient.php
@@ -94,17 +94,7 @@ class GuzzleHttpClient implements HttpClientInterface
             if ($e instanceof RequestExceptionInterface || $e instanceof RequestException) {
                 $response = $e->getResponse();
                 
-                if ($response->getStatusCode() === 403) {
-                    $description = json_decode($response->getBody(), true)['description'];
-
-                    if (Str::contains($description, 'bot was blocked by the user')) {
-                        throw new TelegramUserBlockedException($description);
-                    }
-
-                    if (Str::contains($description, 'user is deactivated')) {
-                        throw new TelegramUserDeactivatedException($description);
-                    }
-                }
+                $this->throwRelatedForbiddenExeptionIfNeeded($response);
             }
 
             if (! $response instanceof ResponseInterface) {
@@ -191,5 +181,29 @@ class GuzzleHttpClient implements HttpClientInterface
     private function getClient(): Client
     {
         return $this->client;
+    }
+    
+    
+    /**
+     * Determine if the user deactivated or blocked the bot then throw related exception
+     * 
+     * @param Response $response
+     * @return void
+     * @throws TelegramUserBlockedException
+     * @throws TelegramUserDeactivatedException
+     */
+    private function throwRelatedForbiddenExeptionIfNeeded(Response $response)
+    {
+        if ($response->getStatusCode() === 403) {
+            $description = json_decode($response->getBody(), true)['description'];
+
+            if (Str::contains($description, 'bot was blocked by the user')) {
+                throw new TelegramUserBlockedException($description);
+            }
+
+            if (Str::contains($description, 'user is deactivated')) {
+                throw new TelegramUserDeactivatedException($description);
+            }
+        }
     }
 }

--- a/src/HttpClients/GuzzleHttpClient.php
+++ b/src/HttpClients/GuzzleHttpClient.php
@@ -13,6 +13,7 @@ use Psr\Http\Client\RequestExceptionInterface;
 use Psr\Http\Message\ResponseInterface;
 use Telegram\Bot\Exceptions\TelegramSDKException;
 use Throwable;
+use Illuminate\Support\Str;
 use Telegram\Bot\Exceptions\TelegramUserBlockedException;
 use Telegram\Bot\Exceptions\TelegramUserDeactivatedException;
 

--- a/src/HttpClients/GuzzleHttpClient.php
+++ b/src/HttpClients/GuzzleHttpClient.php
@@ -9,6 +9,7 @@ use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Promise;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\RequestOptions;
+use GuzzleHttp\Psr7\Response;
 use Psr\Http\Client\RequestExceptionInterface;
 use Psr\Http\Message\ResponseInterface;
 use Telegram\Bot\Exceptions\TelegramSDKException;
@@ -94,7 +95,7 @@ class GuzzleHttpClient implements HttpClientInterface
             if ($e instanceof RequestExceptionInterface || $e instanceof RequestException) {
                 $response = $e->getResponse();
                 
-                $this->throwRelatedForbiddenExeptionIfNeeded($response);
+                $this->throwRelatedForbiddenExceptionIfNeeded($response);
             }
 
             if (! $response instanceof ResponseInterface) {
@@ -192,7 +193,7 @@ class GuzzleHttpClient implements HttpClientInterface
      * @throws TelegramUserBlockedException
      * @throws TelegramUserDeactivatedException
      */
-    private function throwRelatedForbiddenExeptionIfNeeded(Response $response)
+    private function throwRelatedForbiddenExceptionIfNeeded(Response $response)
     {
         if ($response->getStatusCode() === 403) {
             $description = json_decode($response->getBody(), true)['description'];

--- a/tests/Integration/TelegramApiTest.php
+++ b/tests/Integration/TelegramApiTest.php
@@ -349,7 +349,7 @@ class TelegramApiTest extends TestCase
     }
 
     /** @test */
-    public function it_throw_correct_exception_when_user_blocked_the_blot()
+    public function it_throw_correct_exception_when_user_blocked_the_bot()
     {
         $this->expectException(TelegramUserBlockedException::class);
         $badUpdateReply = $this->makeFakeServerErrorResponse(403, 'Forbidden: bot was blocked by the user', 403);

--- a/tests/Integration/TelegramApiTest.php
+++ b/tests/Integration/TelegramApiTest.php
@@ -21,6 +21,7 @@ use Telegram\Bot\TelegramResponse;
 use Telegram\Bot\Tests\Traits\CommandGenerator;
 use Telegram\Bot\Tests\Traits\GuzzleMock;
 use Telegram\Bot\Exceptions\TelegramUserBlockedException;
+use Telegram\Bot\Exceptions\TelegramRateLimitedException;
 use Telegram\Bot\Exceptions\TelegramUserDeactivatedException;
 
 class TelegramApiTest extends TestCase
@@ -353,6 +354,22 @@ class TelegramApiTest extends TestCase
     {
         $this->expectException(TelegramUserBlockedException::class);
         $badUpdateReply = $this->makeFakeServerErrorResponse(403, 'Forbidden: bot was blocked by the user', 403);
+        $api = $this->getApi($this->getGuzzleHttpClient([$badUpdateReply]));
+
+        $api->getUpdates();
+    }
+
+    /** @test */
+    public function it_throw_correct_exception_when_telegram_rate_limited()
+    {
+        $option = [
+            "parameters" => [
+                "retry_after" => 236
+            ]
+        ];
+
+        $this->expectException(TelegramRateLimitedException::class);
+        $badUpdateReply = $this->makeFakeServerErrorResponse(429, 'Too Many Requests: retry after 236', 429, [], $option);
         $api = $this->getApi($this->getGuzzleHttpClient([$badUpdateReply]));
 
         $api->getUpdates();

--- a/tests/Integration/TelegramApiTest.php
+++ b/tests/Integration/TelegramApiTest.php
@@ -20,6 +20,8 @@ use Telegram\Bot\Objects\Update;
 use Telegram\Bot\TelegramResponse;
 use Telegram\Bot\Tests\Traits\CommandGenerator;
 use Telegram\Bot\Tests\Traits\GuzzleMock;
+use Telegram\Bot\Exceptions\TelegramUserBlockedException;
+use Telegram\Bot\Exceptions\TelegramUserDeactivatedException;
 
 class TelegramApiTest extends TestCase
 {
@@ -334,6 +336,26 @@ class TelegramApiTest extends TestCase
         }
 
         $this->fail('Should have caught an exception because the update waiting for us was not ok.');
+    }
+
+    /** @test */
+    public function it_throw_correct_exception_when_user_deactivated()
+    {
+        $this->expectException(TelegramUserDeactivatedException::class);
+        $badUpdateReply = $this->makeFakeServerErrorResponse(403, 'Forbidden: user is deactivated', 403);
+        $api = $this->getApi($this->getGuzzleHttpClient([$badUpdateReply]));
+
+        $api->getUpdates();
+    }
+
+    /** @test */
+    public function it_throw_correct_exception_when_user_blocked_the_blot()
+    {
+        $this->expectException(TelegramUserBlockedException::class);
+        $badUpdateReply = $this->makeFakeServerErrorResponse(403, 'Forbidden: bot was blocked by the user', 403);
+        $api = $this->getApi($this->getGuzzleHttpClient([$badUpdateReply]));
+
+        $api->getUpdates();
     }
 
     /**

--- a/tests/Integration/TelegramApiTest.php
+++ b/tests/Integration/TelegramApiTest.php
@@ -390,7 +390,7 @@ class TelegramApiTest extends TestCase
 
             $api->getUpdates();
         } catch (TelegramRateLimitedException $e) {
-            $this->assertSame($e->getValue(), 236);
+            $this->assertSame($e->getThresholdValue(), 236);
         }
     }
 

--- a/tests/Integration/TelegramApiTest.php
+++ b/tests/Integration/TelegramApiTest.php
@@ -374,6 +374,25 @@ class TelegramApiTest extends TestCase
 
         $api->getUpdates();
     }
+    
+    /** @test */
+    public function it_should_get_the_threshold_value_when_rate_limited()
+    {
+        try {
+            $option = [
+                "parameters" => [
+                    "retry_after" => 236
+                ]
+            ];
+
+            $badUpdateReply = $this->makeFakeServerErrorResponse(429, 'Too Many Requests: retry after 236', 429, [], $option);
+            $api = $this->getApi($this->getGuzzleHttpClient([$badUpdateReply]));
+
+            $api->getUpdates();
+        } catch (TelegramRateLimitedException $e) {
+            $this->assertSame($e->getValue(), 236);
+        }
+    }
 
     /**
      * @test

--- a/tests/Traits/GuzzleMock.php
+++ b/tests/Traits/GuzzleMock.php
@@ -84,16 +84,18 @@ trait GuzzleMock
         return collect($this->history);
     }
 
-    protected function makeFakeServerErrorResponse($error_code, $description, $status_code = 200, $headers = [])
+    protected function makeFakeServerErrorResponse($error_code, $description, $status_code = 200, $headers = [], array $options = null)
     {
+        $params = array_merge([
+            'ok'          => false,
+            'error_code'  => $error_code,
+            'description' => "$description",
+        ], $options);
+            
         return new Response(
             $status_code,
             $headers,
-            json_encode([
-                'ok'          => false,
-                'error_code'  => $error_code,
-                'description' => "$description",
-            ])
+            json_encode($params)
         );
     }
 


### PR DESCRIPTION
Added three useful exceptions:

`TelegramUserBlockedException` When we try to send message but the user blocked our bots
`TelegramUserDeactivated` When we send message but the user deactivated
`TelegramRateLimitedException ` Imagine you want to send an important message to user but you were rate limited (also telegram rate limits if their server was not available at the moment)

Before: ❌

```php
try {
    Telegram::sendMessage([...]);
} catch (TelegramSDKException $e) {
    if (str_contains($e->getMessage(), 'block the bot')) {
        //stop sending daily messages
    }

    if (str_contains($e->getMessage(), 'retry after')) {
        // queue message for sending later
    }

    if (str_contains($e->getMessage(), 'deactivated')) {
        //do something else
    }
}
```

After: ✅

```php
try {
    Telegram::sendMessage([...]);
} catch (TelegramUserBlockedException) {
    //stop sending daily messages
} catch (TelegramUserDeactivatedException) {
    //do something else
} catch (TelegramRateLimitedException $e) {
    $this->dispatchLater($e->getThresholdValue());
}
```

No breaking change intended.