### PR TITLE
Added the ability to specify a custom web server for bots

### DIFF
--- a/src/BotsManager.php
+++ b/src/BotsManager.php
@@ -198,6 +198,10 @@ class BotsManager
             $this->getConfig('http_client_handler', null)
         );
 
+        if ($telegramBotServer = data_get($config, 'telegram_bot_server')) {
+            $telegram->setBotServerUrl($telegramBotServer);
+        }
+
         // Check if DI needs to be enabled for Commands
         if ($this->getConfig('resolve_command_dependencies', false) && isset($this->container)) {
             $telegram->setContainer($this->container);

--- a/src/Laravel/config/telegram.php
+++ b/src/Laravel/config/telegram.php
@@ -14,28 +14,36 @@ return [
     |
     | - name: The *personal* name you would like to refer to your bot as.
     |
-    |       - username: Your Telegram Bot's Username.
-    |                       Example: (string) 'BotFather'.
+    |       - username:            Your Telegram Bot's Username.
+    |                              Example: (string) 'BotFather'.
     |
-    |       - token:    Your Telegram Bot's Access Token.
-                        Refer for more details: https://core.telegram.org/bots#botfather
-    |                   Example: (string) '123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11'.
+    |       - token:               Your Telegram Bot's Access Token.
+    |                              Refer for more details: https://core.telegram.org/bots#botfather
+    |                              Example: (string) '123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11'.
     |
-    |       - commands: (Optional) Commands to register for this bot,
-    |                   Supported Values: "Command Group Name", "Shared Command Name", "Full Path to Class".
-    |                   Default: Registers Global Commands.
-    |                   Example: (array) [
-    |                       'admin', // Command Group Name.
-    |                       'status', // Shared Command Name.
-    |                       Acme\Project\Commands\BotFather\HelloCommand::class,
-    |                       Acme\Project\Commands\BotFather\ByeCommand::class,
-    |             ]
+    |       - telegram_bot_server: (Optional) Using a Local Bot API Server
+    |                              The Bot API server source code is available at telegram-bot-api. You can run it
+    |                              locally and send the requests to your own server instead of https://api.telegram.org.
+    |                              Refer for more details: https://core.telegram.org/bots/api#webhookinfo
+    |                              Example: (string) 'http://localhost:8081/bot'.
+    |                              Example if you are using docker: (string) 'http://container-name:8081/bot'.
+    |
+    |       - commands:            (Optional) Commands to register for this bot,
+    |                              Supported Values: "Command Group Name", "Shared Command Name", "Full Path to Class".
+    |                              Default: Registers Global Commands.
+    |                              Example: (array) [
+    |                                  'admin', // Command Group Name.
+    |                                  'status', // Shared Command Name.
+    |                                  Acme\Project\Commands\BotFather\HelloCommand::class,
+    |                                  Acme\Project\Commands\BotFather\ByeCommand::class,
+    |                              ]
     */
     'bots'                         => [
         'mybot' => [
             'username'            => 'TelegramBot',
             'token'               => env('TELEGRAM_BOT_TOKEN', 'YOUR-BOT-TOKEN'),
             'certificate_path'    => env('TELEGRAM_CERTIFICATE_PATH', 'YOUR-CERTIFICATE-PATH'),
+            'telegram_bot_server' => env('TELEGRAM_BOT_SERVER_URL', 'YOUR-TELEGRAM-BOT-SERVER-URL'),
             'webhook_url'         => env('TELEGRAM_WEBHOOK_URL', 'YOUR-BOT-WEBHOOK-URL'),
             'commands'            => [
                 //Acme\Project\Commands\MyTelegramBot\BotCommand::class

--- a/src/TelegramClient.php
+++ b/src/TelegramClient.php
@@ -13,20 +13,23 @@ use Telegram\Bot\HttpClients\HttpClientInterface;
  */
 class TelegramClient
 {
-    /** @var string Telegram Bot API URL. */
-    const BASE_BOT_URL = 'https://api.telegram.org/bot';
-
     /** @var HttpClientInterface|null HTTP Client. */
     protected $httpClientHandler;
+
+    /** @var string Telegram Bot API Server URL. */
+    protected $botServerUrl;
 
     /**
      * Instantiates a new TelegramClient object.
      *
      * @param HttpClientInterface|null $httpClientHandler
+     * @param string|null              $botServerUrl
      */
-    public function __construct(HttpClientInterface $httpClientHandler = null)
+    public function __construct(HttpClientInterface $httpClientHandler = null, string $botServerUrl = null)
     {
         $this->httpClientHandler = $httpClientHandler ?? new GuzzleHttpClient();
+
+        $this->botServerUrl = $botServerUrl ?? 'https://api.telegram.org/bot';
     }
 
     /**
@@ -97,7 +100,7 @@ class TelegramClient
      */
     public function prepareRequest(TelegramRequest $request): array
     {
-        $url = $this->getBaseBotUrl().$request->getAccessToken().'/'.$request->getEndpoint();
+        $url = $this->getBotServerUrl().$request->getAccessToken().'/'.$request->getEndpoint();
 
         return [
             $url,
@@ -108,13 +111,13 @@ class TelegramClient
     }
 
     /**
-     * Returns the base Bot URL.
+     * Returns the base Telegram Bot API Server URL.
      *
      * @return string
      */
-    public function getBaseBotUrl(): string
+    public function getBotServerUrl(): string
     {
-        return static::BASE_BOT_URL;
+        return $this->botServerUrl;
     }
 
     /**

--- a/src/Traits/Http.php
+++ b/src/Traits/Http.php
@@ -23,6 +23,9 @@ trait Http
     /** @var TelegramClient The Telegram client service. */
     protected $client = null;
 
+    /** @var string|null Telegram Bot API Server URL. */
+    protected $botServerUrl = null;
+
     /** @var HttpClientInterface|null Http Client Handler */
     protected $httpClientHandler = null;
 
@@ -37,6 +40,35 @@ trait Http
 
     /** @var TelegramResponse|null Stores the last request made to Telegram Bot API. */
     protected $lastResponse;
+
+    /**
+     * Using a Local Bot API Server
+     *
+     * The Bot API server source code is available at telegram-bot-api. You can run it locally and send the requests to
+     * your own server instead of https://api.telegram.org. If you switch to a local Bot API server, your bot will be
+     * able to:
+     * - Download files without a size limit.
+     * - Upload files up to 2000 MB.
+     * - Upload files using their local path and the file URI scheme.
+     * - Use an HTTP URL for the webhook.
+     * - Use any local IP address for the webhook.
+     * - Use any port for the webhook.
+     * - Set max_webhook_connections up to 100000.
+     * - Receive the absolute local path as a value of the file_path field without the need to download the file after a
+     * getFile request.
+     *
+     * @link https://core.telegram.org/bots/api#using-a-local-bot-api-server
+     *
+     * @param string $botServerUrl
+     *
+     * @return $this
+     */
+    public function setBotServerUrl(string $botServerUrl): self
+    {
+        $this->botServerUrl = $botServerUrl;
+
+        return $this;
+    }
 
     /**
      * Set Http Client Handler.
@@ -60,7 +92,7 @@ trait Http
     protected function getClient(): TelegramClient
     {
         if ($this->client === null) {
-            $this->client = new TelegramClient($this->httpClientHandler);
+            $this->client = new TelegramClient($this->httpClientHandler, $this->botServerUrl);
         }
 
         return $this->client;


### PR DESCRIPTION
Telegram allows you to create custom server bots. This PR adds support for using your own web server. Detailed documentation describing this method and its advantages can be found on these pages:

https://core.telegram.org/bots/api#using-a-local-bot-api-server

https://github.com/tdlib/telegram-bot-api