### PR TITLE
Backport some v4 features

### DIFF
--- a/src/Actions.php
+++ b/src/Actions.php
@@ -12,32 +12,47 @@ namespace Telegram\Bot;
 class Actions
 {
     /** Sets chat status as Typing. */
-    const TYPING = 'typing';
+    public const TYPING = 'typing';
 
     /** Sets chat status as Sending Photo. */
-    const UPLOAD_PHOTO = 'upload_photo';
+    public const UPLOAD_PHOTO = 'upload_photo';
 
     /** Sets chat status as Recording Video. */
-    const RECORD_VIDEO = 'record_video';
+    public const RECORD_VIDEO = 'record_video';
 
     /** Sets chat status as Sending Video. */
-    const UPLOAD_VIDEO = 'upload_video';
+    public const UPLOAD_VIDEO = 'upload_video';
 
-    /** Sets chat status as Recording Audio. */
-    const RECORD_AUDIO = 'record_audio';
+    /**
+     * @deprecated Please use RECORD_VOICE (the correct one)
+     * Sets chat status as Recording Audio.
+     */
+    public const RECORD_AUDIO = 'record_voice';
 
-    /** Sets chat status as Sending Audio. */
-    const UPLOAD_AUDIO = 'upload_audio';
+    /** Sets chat status as Recording Voice. */
+    public const RECORD_VOICE = 'record_voice';
+
+    /**
+     * @deprecated Please use UPLOAD_VOICE (the correct one)
+     * Sets chat status as Sending Audio.
+     */
+    public const UPLOAD_AUDIO = 'upload_voice';
+
+    /** Sets chat status as Sending Voice. */
+    public const UPLOAD_VOICE = 'upload_voice';
 
     /** Sets chat status as Sending Document. */
-    const UPLOAD_DOCUMENT = 'upload_document';
+    public const UPLOAD_DOCUMENT = 'upload_document';
+
+    /** Sets chat status as Choosing Sticker. */
+    public const CHOOSE_STICKER = 'choose_sticker';
 
     /** Sets chat status as Choosing Geo. */
-    const FIND_LOCATION = 'find_location';
+    public const FIND_LOCATION = 'find_location';
 
     /** Sets chat status as Recording Video Note. */
-    const RECORD_VIDEO_NOTE = 'record_video_note';
+    public const RECORD_VIDEO_NOTE = 'record_video_note';
 
     /** Sets chat status as Sending Video Note. */
-    const UPLOAD_VIDEO_NOTE = 'upload_video_note';
+    public const UPLOAD_VIDEO_NOTE = 'upload_video_note';
 }

--- a/src/Api.php
+++ b/src/Api.php
@@ -64,6 +64,7 @@ class Api
     }
 
     /**
+     * @deprecated This method will be removed in SDK v4.
      * Invoke Bots Manager.
      *
      * @param $config

--- a/src/EntityType.php
+++ b/src/EntityType.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Telegram\Bot;
+
+/**
+ * Class EntityType.
+ */
+final class EntityType
+{
+    /** Sets MessageEntity Type as mention. */
+    public const MENTION = 'mention';
+
+    /** Sets MessageEntity Type as hashtag . */
+    public const HASHTAG = 'hashtag';
+
+    /** Sets MessageEntity Type as cashtag. */
+    public const CASHTAG = 'cashtag';
+
+    /** Sets MessageEntity Type as Bot Command. */
+    public const BOT_COMMAND = 'bot_command';
+
+    /** Sets MessageEntity Type as url. */
+    public const URL = 'url';
+
+    /** Sets MessageEntity Type as email. */
+    public const EMAIL = 'email';
+
+    /** Sets MessageEntity Type as phone number. */
+    public const PHONE_NUMBER = 'phone_number';
+
+    /** Sets MessageEntity Type as bold. */
+    public const BOLD = 'bold';
+
+    /** Sets MessageEntity Type as italic. */
+    public const ITALIC = 'italic';
+
+    /** Sets MessageEntity Type as underline. */
+    public const UNDERLINE = 'underline';
+
+    /** Sets MessageEntity Type as strike through. */
+    public const STRIKETHROUGH = 'strikethrough';
+
+    /** Sets MessageEntity Type as spoiler . */
+    public const SPOILER = 'spoiler';
+
+    /** Sets MessageEntity Type as code. */
+    public const CODE = 'code';
+
+    /** Sets MessageEntity Type as pre. */
+    public const PRE = 'code';
+
+    /** Sets MessageEntity Type as text link. */
+    public const TEXT_LINK = 'text_link';
+
+    /** Sets MessageEntity Type as text mention. */
+    public const TEXT_MENTION = 'text_mention';
+}

--- a/src/Methods/Chat.php
+++ b/src/Methods/Chat.php
@@ -3,19 +3,20 @@
 namespace Telegram\Bot\Methods;
 
 use Telegram\Bot\Exceptions\TelegramSDKException;
-use Telegram\Bot\FileUpload\InputFile;
 use Telegram\Bot\Objects\Chat as ChatObject;
 use Telegram\Bot\Objects\ChatMember;
-use Telegram\Bot\Objects\ChatPermissions;
 use Telegram\Bot\Traits\Http;
 
 /**
  * Class Chat.
+ *
  * @mixin Http
  */
 trait Chat
 {
     /**
+     * @deprecated Method will be removed in v4, please use banChatMember() instead.
+     *
      * Kick a user from a group or a supergroup.
      *
      * In the case of supergroups, the user will not be able to return to the group on their own using
@@ -54,33 +55,183 @@ trait Chat
     }
 
     /**
+     * Ban a user in a group, a supergroup or a channel
+     *
+     * In the case of supergroups, the user will not be able to return to the group on their own using
+     * invite links etc., unless unbanned first.
+     *
+     * The bot must be an administrator in the group for this to work.
+     *
+     * Note: This will method only work if the ‘All Members Are Admins’ setting is off in the target group.
+     * Otherwise members may only be removed by the group's creator or by the member that added them.
+     *
+     * <code>
+     * $params = [
+     *      'chat_id'         => '',  // int|string - Required. Unique identifier for the target group or username of the target supergroup (in the format "@supergroupusername")
+     *      'user_id'         => '',  // int        - Required. Unique identifier of the target user.
+     *      'until_date'      => '',  // int        - (Optional). Date when the user will be unbanned, unix time. If user is banned for more than 366 days or less than 30 seconds from the current time they are considered to be banned forever. Applied for supergroups and channels only.
+     *      'revoke_messages' => '',  // bool       - (Optional). Pass True to delete all messages from the chat for the user that is being removed. If False, the user will be able to see messages in the group that were sent before the user was removed. Always True for supergroups and channels.
+     * ]
+     * </code>
+     *
+     * @link https://core.telegram.org/bots/api#banchatmember
+     *
+     * @param array $params
+     *
+     * @throws TelegramSDKException
+     * @return bool
+     */
+    public function banChatMember(array $params): bool
+    {
+        return $this->get('banChatMember', $params)->getResult();
+    }
+
+    /**
      * Export an invite link to a supergroup or a channel.
      *
      * The bot must be an administrator in the group for this to work.
      *
      * <code>
      * $params = [
-     *   'chat_id'              => ''
-     * ];
+     *      'chat_id'  => '',  // string|int - Unique identifier for the target chat or username of the target channel (in the format "@channelusername")
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#exportchatinvitelink
      *
-     * @param array    $params  [
-     *
-     * @var string|int $chat_id Unique identifier for the target chat or username of the target channel (in the format @channelusername)
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
-     *
      * @return string
      */
     public function exportChatInviteLink(array $params): string
     {
-        $response = $this->post('exportChatInviteLink', $params);
+        return $this->post('exportChatInviteLink', $params)->getResult();
+    }
 
-        return $response->getResult();
+    /**
+     * Create an additional invite link for a chat
+     *
+     * The bot must be an administrator in the group for this to work.
+     *
+     * <code>
+     * $params = [
+     *      'chat_id'               => '',  // string|int - Required. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+     *      'name'                  => '',  // string     - (Optional).	Invite link name; 0-32 characters
+     *      'expire_date'           => '',  // int        - (Optional). Point in time (Unix timestamp) when the link will expire
+     *      'member_limit'          => '',  // int        - (Optional). Maximum number of users that can be members of the chat simultaneously after joining the chat via this invite link; 1-99999
+     *      'creates_join_request'  => '',  // bool       - (Optional). True, if users joining the chat via the link need to be approved by chat administrators. If True, member_limit can't be specified
+     * ]
+     * </code>
+     *
+     * @link https://core.telegram.org/bots/api#createchatinvitelink
+     *
+     * @param array $params
+     *
+     * @throws TelegramSDKException
+     * @return ChatInviteLink
+     */
+    public function createChatInviteLink(array $params): ChatInviteLink
+    {
+        return $this->post('createChatInviteLink', $params)->getResult();
+    }
+
+    /**
+     * Edit a non-primary invite link created by the bot.
+     *
+     * The bot must be an administrator in the group for this to work.
+     *
+     * <code>
+     * $params = [
+     *      'chat_id'               => '',  // string|int - Required. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+     *      'invite_link'           => '',  // string     - Required. The invite link to edit
+     *      'name'                  => '',  // string     - (Optional).	Invite link name; 0-32 characters
+     *      'expire_date'           => '',  // int        - (Optional). Point in time (Unix timestamp) when the link will expire
+     *      'member_limit'          => '',  // int        - (Optional). Maximum number of users that can be members of the chat simultaneously after joining the chat via this invite link; 1-99999
+     *      'creates_join_request'  => '',  // bool       - (Optional). True, if users joining the chat via the link need to be approved by chat administrators. If True, member_limit can't be specified
+     * ]
+     * </code>
+     *
+     * @link https://core.telegram.org/bots/api#editchatinvitelink
+     *
+     * @param array $params
+     *
+     * @throws TelegramSDKException
+     * @return ChatInviteLink
+     */
+    public function editChatInviteLink(array $params): ChatInviteLink
+    {
+        return $this->post('editChatInviteLink', $params)->getResult();
+    }
+
+    /**
+     * Revoke an invite link created by the bot.
+     *
+     * The bot must be an administrator in the group for this to work.
+     *
+     * <code>
+     * $params = [
+     *      'chat_id'               => '',  // string|int - Required. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+     *      'invite_link'           => '',  // string     - Required. The invite link to revoke
+     * ]
+     * </code>
+     *
+     * @link https://core.telegram.org/bots/api#revokechatinvitelink
+     *
+     * @param array $params
+     *
+     * @throws TelegramSDKException
+     * @return ChatInviteLink
+     */
+    public function revokeChatInviteLink(array $params): ChatInviteLink
+    {
+        return $this->post('revokeChatInviteLink', $params)->getResult();
+    }
+
+    /**
+     * Approve a chat join request
+     *
+     * The bot must be an administrator in the group for this to work.
+     *
+     * <code>
+     * $params = [
+     *      'chat_id'       => '',  // string|int - Required. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+     *      'user_id'       => '',  // int        - Required. Unique identifier of the target user
+     * ]
+     * </code>
+     *
+     * @link https://core.telegram.org/bots/api#approvechatjoinrequest
+     *
+     * @param array $params
+     *
+     * @return bool
+     */
+    public function approveChatJoinRequest(array $params): bool
+    {
+        return $this->post('approveChatJoinRequest', $params)->getResult();
+    }
+
+    /**
+     * Decline a chat join request
+     *
+     * The bot must be an administrator in the group for this to work.
+     *
+     * <code>
+     * $params = [
+     *      'chat_id'       => '',  // string|int - Required. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+     *      'user_id'       => '',  // int        - Required. Unique identifier of the target user
+     * ]
+     * </code>
+     *
+     * @link https://core.telegram.org/bots/api#declinechatjoinrequest
+     *
+     * @param array $params
+     *
+     * @return bool
+     */
+    public function declineChatJoinRequest(array $params): bool
+    {
+        return $this->post('declineChatJoinRequest', $params)->getResult();
     }
 
     /**
@@ -90,29 +241,21 @@ trait Chat
      *
      * <code>
      * $params = [
-     *   'chat_id'              => ''
-     *   'photo'                => ''
-     * ];
+     *      'chat_id'  => '',                     // string|int - Required. Unique identifier for the target chat or username of the target channel (in the format "@channelusername")
+     *      'photo'    => InputFile::file($file), // InputFile  - Required. New chat photo, uploaded using multipart/form-data
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#setchatphoto
      *
-     * @param array    $params  [
-     *
-     * @var string|int $chat_id Required. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
-     * @var InputFile  $photo   Required. New chat photo, uploaded using multipart/form-data
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
-     *
      * @return bool
      */
     public function setChatPhoto(array $params): bool
     {
-        $response = $this->post('setChatPhoto', $params);
-
-        return $response->getResult();
+        return $this->post('setChatPhoto', $params)->getResult();
     }
 
     /**
@@ -122,27 +265,20 @@ trait Chat
      *
      * <code>
      * $params = [
-     *   'chat_id'              => ''
-     * ];
+     *      'chat_id'  => '',  // string|int - Required. Unique identifier for the target chat or username of the target channel (in the format "@channelusername")
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#deletechatphoto
      *
-     * @param array    $params  [
-     *
-     * @var string|int $chat_id Required. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
-     *
      * @return bool
      */
     public function deleteChatPhoto(array $params): bool
     {
-        $response = $this->post('deleteChatPhoto', $params);
-
-        return $response->getResult();
+        return $this->post('deleteChatPhoto', $params)->getResult();
     }
 
     /**
@@ -152,29 +288,21 @@ trait Chat
      *
      * <code>
      * $params = [
-     *   'chat_id'              => ''
-     *   'title'                => ''
-     * ];
+     *      'chat_id'  => '',  // string|int - Required. Unique identifier for the target chat or username of the target channel (in the format "@channelusername")
+     *      'title'    => '',  // string     - Required. New chat title, 1-255 characters
+     * ]
      * </code>
      *
-     * @link https://core.telegram.org/bots/api#setchatdescription
+     * @link https://core.telegram.org/bots/api#setchattitle
      *
-     * @param array    $params  [
-     *
-     * @var string|int $chat_id Required. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
-     * @var string     $photo   Required. New chat title, 1-255 characters
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
-     *
      * @return bool
      */
     public function setChatTitle(array $params): bool
     {
-        $response = $this->post('setChatTitle', $params);
-
-        return $response->getResult();
+        return $this->post('setChatTitle', $params)->getResult();
     }
 
     /**
@@ -184,29 +312,21 @@ trait Chat
      *
      * <code>
      * $params = [
-     *   'chat_id'              => ''
-     *   'description'          => ''
-     * ];
+     *      'chat_id'      => '',  // string|int - Required. Unique identifier for the target chat or username of the target channel (in the format "@channelusername")
+     *      'description'  => '',  // string     - (Optional). New chat description, 0 - 255 characters.
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#setchatdescription
      *
-     * @param array    $params      [
-     *
-     * @var string|int $chat_id     Required. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
-     * @var string     $description (Optional). New chat description, 0-255 characters.
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
-     *
      * @return bool
      */
     public function setChatDescription(array $params): bool
     {
-        $response = $this->post('setChatDescription', $params);
-
-        return $response->getResult();
+        return $this->post('setChatDescription', $params)->getResult();
     }
 
     /**
@@ -217,31 +337,22 @@ trait Chat
      *
      * <code>
      * $params = [
-     *   'chat_id'                   => ''
-     *   'message_id'                => ''
-     *   'disable_notification'      => ''
-     * ];
+     *      'chat_id'               => '',  // string|int - Required. Unique identifier for the target chat or username of the target channel (in the format "@channelusername")
+     *      'message_id'            => '',  // int        - Required. Identifier of a message to pin
+     *      'disable_notification'  => '',  // bool       - (Optional). Pass True, if it is not necessary to send a notification to all group members about the new pinned message
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#pinchatmessage
      *
-     * @param array    $params               [
-     *
-     * @var string|int $chat_id              Required. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
-     * @var int        $message_id           Required. Identifier of a message to pin
-     * @var bool       $disable_notification (Optional). Pass True, if it is not necessary to send a notification to all group members about the new pinned message
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
-     *
      * @return bool
      */
     public function pinChatMessage(array $params): bool
     {
-        $response = $this->post('pinChatMessage', $params);
-
-        return $response->getResult();
+        return $this->post('pinChatMessage', $params)->getResult();
     }
 
     /**
@@ -254,27 +365,46 @@ trait Chat
      *
      * <code>
      * $params = [
-     *   'chat_id'              => ''
-     * ];
+     *      'chat_id'     => '',  // string|int - Required. Unique identifier for the target chat or username of the target channel (in the format "@channelusername")
+     *      'message_id'  => '',  // int        - (Optional). Identifier of a message to unpin. If not specified, the most recent pinned message (by sending date) will be unpinned.
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#unpinchatmessage
      *
-     * @param array    $params  [
-     *
-     * @var string|int $chat_id Required. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
-     *
      * @return bool
      */
     public function unpinChatMessage(array $params): bool
     {
-        $response = $this->post('unpinChatMessage', $params);
+        return $this->post('unpinChatMessage', $params)->getResult();
+    }
 
-        return $response->getResult();
+    /**
+     * Unpin/clear the list of pinned messages in a chat.
+     *
+     * If the chat is not a private chat, the bot must be an administrator in the chat for this to work
+     * and must have the 'can_pin_messages' admin right in a supergroup or 'can_edit_messages' admin right
+     * in a channel.
+     *
+     * <code>
+     * $params = [
+     *      'chat_id'     => '',  // string|int - Required. Unique identifier for the target chat or username of the target channel (in the format "@channelusername")
+     * ]
+     * </code>
+     *
+     * @link https://core.telegram.org/bots/api#unpinallchatmessages
+     *
+     * @param array $params
+     *
+     * @throws TelegramSDKException
+     * @return bool
+     */
+    public function unpinAllChatMessages(array $params): bool
+    {
+        return $this->post('unpinAllChatMessages', $params)->getResult();
     }
 
     /**
@@ -282,20 +412,15 @@ trait Chat
      *
      * <code>
      * $params = [
-     *   'chat_id'              => ''
-     * ];
+     *      'chat_id'  => '',  // string|int - Unique identifier for the target chat or username of the target supergroup or channel (in the format "@channelusername")
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#leavechat
      *
-     * @param array    $params  [
-     *
-     * @var string|int $chat_id Unique identifier for the target chat or username of the target supergroup or channel (in the format @channelusername)
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
-     *
      * @return bool
      */
     public function leaveChat(array $params): bool
@@ -312,22 +437,17 @@ trait Chat
      *
      * <code>
      * $params = [
-     *   'chat_id'              => '',
-     *   'user_id'              => '',
-     * ];
+     *      'chat_id'        => '',  // int|string - Unique identifier for the target group or username of the target supergroup (in the format "@supergroupusername")
+     *      'user_id'        => '',  // int        - Unique identifier of the target user.
+     *      'only_if_banned' => '',  // bool       - (Optional). Do nothing if the user is not banned
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#unbanchatmember
      *
-     * @param array    $params  [
-     *
-     * @var int|string $chat_id Unique identifier for the target group or username of the target supergroup (in the format @supergroupusername)
-     * @var int        $user_id Unique identifier of the target user.
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
-     *
      * @return bool
      */
     public function unbanChatMember(array $params): bool
@@ -344,35 +464,23 @@ trait Chat
      *
      * <code>
      * $params = [
-     *   'chat_id'                     => '',
-     *   'user_id'                     => '',
-     *   'until_date'                  => '',
-     *   'can_send_messages'           => '',
-     *   'can_send_media_messages'     => '',
-     *   'can_send_other_messages'     => '',
-     *   'can_add_web_page_previews'   => '',
-     * ];
+     *      'chat_id'      => '',  // int|string      - Required. Unique identifier for the target group or username of the target supergroup (in the format "@supergroupusername")
+     *      'user_id'      => '',  // int             - Required. Unique identifier of the target user.
+     *      'permissions'  => '',  // ChatPermissions - Required.  New user permissions
+     *      'until_date'   => '',  // int             - (Optional). Date when restrictions will be lifted for the user, unix time. If user is restricted for more than 366 days or less than 30 seconds from the current time, they are considered to be restricted forever.
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#restrictchatmember
      *
-     * @param array    $params                    [
-     *
-     * @var int|string      $chat_id        Required. Unique identifier for the target group or username of the target supergroup (in the format @supergroupusername)
-     * @var int             $user_id        Required. Unique identifier of the target user.
-     * @var ChatPermissions $permissions    Required.  New user permissions
-     * @var int             $until_date     (Optional). Date when restrictions will be lifted for the user, unix time. If user is restricted for more than 366 days or less than 30 seconds from the current time, they are considered to be restricted forever.
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
-     *
      * @return bool
      */
     public function restrictChatMember(array $params): bool
     {
-        $response = $this->post('restrictChatMember', $params);
-
-        return $response->getResult();
+        return $this->post('restrictChatMember', $params)->getResult();
     }
 
     /**
@@ -384,45 +492,32 @@ trait Chat
      *
      * <code>
      * $params = [
-     *   'chat_id'               => '',
-     *   'user_id'               => '',
-     *   'can_change_info'       => '',
-     *   'can_post_messages'     => '',
-     *   'can_edit_messages'     => '',
-     *   'can_delete_messages'   => '',
-     *   'can_invite_users'      => '',
-     *   'can_restrict_members'  => '',
-     *   'can_pin_messages'      => '',
-     *   'can_promote_members'   => '',
-     * ];
+     *      'chat_id'               => '',  // int|string - Required. Unique identifier for the target group or username of the target supergroup (in the format "@supergroupusername")
+     *      'user_id'               => '',  // int        - Required. Unique identifier of the target user.
+     *      'is_anonymous'          => '',  // bool       - (Optional). Pass True, if the administrator's presence in the chat is hidden
+     *      'can_manage_chat    '   => '',  // bool       - (Optional). Pass True, if the administrator can access the chat event log, chat statistics, message statistics in channels, see channel members, see anonymous administrators in supergroups and ignore slow mode. Implied by any other administrator privilege
+     *      'can_change_info'       => '',  // bool       - (Optional). Pass True, if the administrator can change chat title, photo and other settings
+     *      'can_post_messages'     => '',  // bool       - (Optional). Pass True, if the administrator can create channel posts, channels only
+     *      'can_edit_messages'     => '',  // bool       - (Optional). Pass True, if the administrator can edit messages of other users, channels only
+     *      'can_delete_messages'   => '',  // bool       - (Optional). Pass True, if the administrator can delete messages of other users
+     *      'can_invite_users'      => '',  // bool       - (Optional). Pass True, if the administrator can invite new users to the chat
+     *      'can_manage_voice_chats'=> '',  // bool       - (Optional). Pass True, if the administrator can manage voice chats
+     *      'can_restrict_members'  => '',  // bool       - (Optional). Pass True, if the administrator can restrict, ban or unban chat members
+     *      'can_pin_messages'      => '',  // bool       - (Optional). Pass True, if the administrator can pin messages, supergroups only
+     *      'can_promote_members'   => '',  // bool       - (Optional). Pass True, if the administrator can add new administrators with a subset of his own privileges or demote administrators that he has promoted, directly or indirectly (promoted by administrators that were appointed by him)
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#restrictchatmember
      *
-     * @param array    $params               [
-     *
-     * @var int|string $chat_id              Required. Unique identifier for the target group or username of the target supergroup (in the format @supergroupusername)
-     * @var int        $user_id              Required. Unique identifier of the target user.
-     * @var bool       $can_change_info      (Optional). Pass True, if the administrator can change chat title, photo and other settings
-     * @var bool       $can_post_messages    (Optional). Pass True, if the administrator can create channel posts, channels only
-     * @var bool       $can_edit_messages    (Optional). Pass True, if the administrator can edit messages of other users, channels only
-     * @var bool       $can_delete_messages  (Optional). Pass True, if the administrator can delete messages of other users
-     * @var bool       $can_invite_users     (Optional). Pass True, if the administrator can invite new users to the chat
-     * @var bool       $can_restrict_members (Optional). Pass True, if the administrator can restrict, ban or unban chat members
-     * @var bool       $can_pin_messages     (Optional). Pass True, if the administrator can pin messages, supergroups only
-     * @var bool       $can_promote_members  (Optional). Pass True, if the administrator can add new administrators with a subset of his own privileges or demote administrators that he has promoted, directly or indirectly (promoted by administrators that were appointed by him)
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
-     *
      * @return bool
      */
     public function promoteChatMember(array $params): bool
     {
-        $response = $this->post('promoteChatMember', $params);
-
-        return $response->getResult();
+        return $this->post('promoteChatMember', $params)->getResult();
     }
 
     /**
@@ -432,31 +527,73 @@ trait Chat
      *
      * <code>
      * $params = [
-     *   'chat_id'               => '',
-     *   'user_id'               => '',
-     *   'custom_title'           => '',
-     * ];
+     *      'chat_id'       => '',  // int|string - Required. Unique identifier for the target chat or username of the target supergroup (in the format "@supergroupusername")
+     *      'user_id'       => '',  // int        - Required. Unique identifier of the target user
+     *      'custom_title'  => '',  // string     - Required. New custom title for the administrator; 0                                                                      - 16 characters, emoji are not allowed
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#setchatadministratorcustomtitle
      *
-     * @param array         $params      [
-     *
-     * @var int|string      $chat_id      Required. Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
-     * @var int             $user_id      Required. Unique identifier of the target user
-     * @var string          $custom_title Required. New custom title for the administrator; 0-16 characters, emoji are not allowed
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
-     *
      * @return bool
      */
     public function setChatAdministratorCustomTitle(array $params): bool
     {
-        $response = $this->post('setChatAdministratorCustomTitle', $params);
+        return $this->post('setChatAdministratorCustomTitle', $params)->getResult();
+    }
 
-        return $response->getResult();
+    /**
+     * Ban a channel chat in a supergroup or a channel. Until the chat is unbanned, the owner of the banned chat
+     * won't be able to send messages on behalf of any of their channels.
+     *
+     * Returns True on success.
+     *
+     * <code>
+     * $params = [
+     *      'chat_id'         => '',  // int|string - Required. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+     *      'sender_chat_id'  => '',  // int        - Required. Unique identifier of the target sender chat
+     * ]
+     * </code>
+     *
+     * @link https://core.telegram.org/bots/api#banchatsenderchat
+     *
+     * @param array $params
+     *
+     * @throws TelegramSDKException
+     * @return bool
+     */
+    public function banChatSenderChat(array $params): bool
+    {
+        return $this->post('banChatSenderChat', $params)->getResult();
+    }
+
+    /**
+     * Unban a previously banned channel chat in a supergroup or channel.
+     *
+     * The bot must be an administrator for this to work
+     *
+     * Returns True on success.
+     *
+     * <code>
+     * $params = [
+     *      'chat_id'         => '',  // int|string - Required. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+     *      'sender_chat_id'  => '',  // int        - Required. Unique identifier of the target sender chat
+     * ]
+     * </code>
+     *
+     * @link https://core.telegram.org/bots/api#unbanchatsenderchat
+     *
+     * @param array $params
+     *
+     * @throws TelegramSDKException
+     * @return bool
+     */
+    public function unbanChatSenderChat(array $params): bool
+    {
+        return $this->post('unbanChatSenderChat', $params)->getResult();
     }
 
     /**
@@ -466,29 +603,21 @@ trait Chat
      *
      * <code>
      * $params = [
-     *   'chat_id'               => '',
-     *   'permissions'           => '',
-     * ];
+     *      'chat_id'      => '',  // int|string      - Required. Unique identifier for the target group or username of the target supergroup (in the format "@supergroupusername")
+     *      'permissions'  => '',  // ChatPermissions - Required. New default chat permissions
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#setchatpermissions
      *
-     * @param array         $params      [
-     *
-     * @var int|string      $chat_id     Required. Unique identifier for the target group or username of the target supergroup (in the format @supergroupusername)
-     * @var ChatPermissions $permissions Required. New default chat permissions
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
-     *
      * @return bool
      */
     public function setChatPermissions(array $params): bool
     {
-        $response = $this->post('setChatPermissions', $params);
-
-        return $response->getResult();
+        return $this->post('setChatPermissions', $params)->getResult();
     }
 
     /**
@@ -497,17 +626,13 @@ trait Chat
      *
      * <code>
      * $params = [
-     *   'chat_id'  => '',
-     * ];
+     *      'chat_id'  => '',  // string|int - Unique identifier for the target chat or username of the target supergroup or channel (in the format "@channelusername")
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#getchat
      *
-     * @param array    $params  [
-     *
-     * @var string|int $chat_id Unique identifier for the target chat or username of the target supergroup or channel (in the format @channelusername)
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
      *
@@ -525,20 +650,15 @@ trait Chat
      *
      * <code>
      * $params = [
-     *   'chat_id'  => '',
-     * ];
+     *      'chat_id'  => '',  // string|int - Unique identifier for the target chat or username of the target supergroup or channel (in the format "@channelusername");
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#getchatadministrators
      *
-     * @param array    $params  [
-     *
-     * @var string|int $chat_id Unique identifier for the target chat or username of the target supergroup or channel (in the format @channelusername);
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
-     *
      * @return ChatMember[]
      */
     public function getChatAdministrators(array $params): array
@@ -546,9 +666,7 @@ trait Chat
         $response = $this->get('getChatAdministrators', $params);
 
         return collect($response->getResult())
-            ->map(function ($admin) {
-                return new ChatMember($admin);
-            })
+            ->mapInto(ChatMember::class)
             ->all();
     }
 
@@ -557,25 +675,20 @@ trait Chat
      *
      * <code>
      * $params = [
-     *   'chat_id'  => '',
-     * ];
+     *      'chat_id'  => '',  // string|int - Unique identifier for the target chat or username of the target supergroup or channel (in the format "@channelusername").
+     * ]
      * </code>
      *
-     * @link https://core.telegram.org/bots/api#getchatmemberscount
+     * @link https://core.telegram.org/bots/api#getchatmembercount
      *
-     * @param array    $params  [
-     *
-     * @var string|int $chat_id Unique identifier for the target chat or username of the target supergroup or channel (in the format @channelusername).
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
-     *
      * @return int
      */
-    public function getChatMembersCount(array $params): int
+    public function getChatMemberCount(array $params): int
     {
-        return $this->get('getChatMembersCount', $params)->getResult();
+        return $this->get('getChatMemberCount', $params)->getResult();
     }
 
     /**
@@ -583,22 +696,16 @@ trait Chat
      *
      * <code>
      * $params = [
-     *   'chat_id'  => '',
-     *   'user_id'  => '',
-     * ];
+     *      'chat_id'  => '',  // string|int - Unique identifier for the target chat or username of the target supergroup or channel (in the format "@channelusername").
+     *      'user_id'  => '',  // int        - Unique identifier of the target user.
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#getchatmember
      *
-     * @param array    $params  [
-     *
-     * @var string|int $chat_id Unique identifier for the target chat or username of the target supergroup or channel (in the format @channelusername).
-     * @var int        $user_id Unique identifier of the target user.
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
-     *
      * @return ChatMember
      */
     public function getChatMember(array $params): ChatMember
@@ -615,29 +722,21 @@ trait Chat
      *
      * <code>
      * $params = [
-     *   'chat_id'                   => ''
-     *   'sticker_set_name'          => ''
-     * ];
+     *      'chat_id'           => '',  // string|int - Required. Unique identifier for the target chat or username of the target supergroup (in the format "@supergroupusername")
+     *      'sticker_set_name'  => '',  // int        - Required. Name of the sticker set to be set as the group sticker set
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#setchatstickerset
      *
-     * @param array    $params           [
-     *
-     * @var string|int $chat_id          Required. Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
-     * @var int        $sticker_set_name Required. Name of the sticker set to be set as the group sticker set
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
-     *
      * @return bool
      */
     public function setChatStickerSet(array $params): bool
     {
-        $response = $this->post('setChatStickerSet', $params);
-
-        return $response->getResult();
+        return $this->post('setChatStickerSet', $params)->getResult();
     }
 
     /**
@@ -647,26 +746,19 @@ trait Chat
      *
      * <code>
      * $params = [
-     *   'chat_id'                   => ''
-     * ];
+     *      'chat_id'  => '',  // string|int - Required. Unique identifier for the target chat or username of the target supergroup (in the format "@supergroupusername")
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#deletechatstickerset
      *
-     * @param array    $params  [
-     *
-     * @var string|int $chat_id Required. Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
-     *
      * @return bool
      */
     public function deleteChatStickerSet(array $params): bool
     {
-        $response = $this->post('deleteChatStickerSet', $params);
-
-        return $response->getResult();
+        return $this->post('deleteChatStickerSet', $params)->getResult();
     }
 }

--- a/src/Methods/Commands.php
+++ b/src/Methods/Commands.php
@@ -8,55 +8,78 @@ use Telegram\Bot\Exceptions\TelegramSDKException;
 
 /**
  * Class Commands.
+ *
  * @mixin Http
  */
 trait Commands
 {
-
     /**
-     * Get the current list of the bot's commands.
-     *
-     * @link https://core.telegram.org/bots/api#getmycommands
-     *
-     * @return BotCommand[]
-     * @throws TelegramSDKException
-     */
-    public function getMyCommands(): array
-    {
-        $response = $this->get('getMyCommands');
-
-        return collect($response->getResult())
-            ->map(function ($botCommand) {
-                return new BotCommand($botCommand);
-            })
-            ->all();
-    }
-
-    /**
-     * Change the list of the bot's commands.
+     * Change the list of the bots commands.
      *
      * <code>
      * $params = [
-     *   'commands'              => '',
-     * ];
+     *      'commands'      => '',  // array           - Required. A JSON-serialized list of bot commands to be set as the list of the bot's commands. At most 100 commands can be specified.
+     *      'scope'         => '',  // BotCommandScope - (Optional). A JSON-serialized object, describing scope of users for which the commands are relevant. Defaults to BotCommandScopeDefault.
+     *      'language_code' => '',  // String          - (Optional). A two-letter ISO 639-1 language code. If empty, commands will be applied to all users from the given scope, for whose language there are no dedicated commands
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#setmycommands
      *
-     * @param array $params   [
-     *
-     * @var array   $commands Required. A JSON-serialized list of bot commands to be set as the list of the bot's commands. At most 100 commands can be specified.
-     *
-     * ]
+     * @param array $params Where "commands" key is required, where value is a serialized array of commands.
      *
      * @throws TelegramSDKException
-     *
-     * @return Bool
+     * @return bool
      */
-    public function setMyCommands(array $params): Bool
+    public function setMyCommands(array $params): bool
     {
-        $params['commands'] = json_encode($params['commands']);
+        $params['commands'] = is_string($params['commands'])
+            ? $params['commands']
+            : json_encode($params['commands']);
 
         return $this->post('setMyCommands', $params)->getResult();
+    }
+
+    /**
+     * Delete the list of the bot's commands for the given scope and user language
+     *
+     * <code>
+     * $params = [
+     *      'scope'         => '',  // BotCommandScope - (Optional). A JSON-serialized object, describing scope of users for which the commands are relevant. Defaults to BotCommandScopeDefault.
+     *      'language_code' => '',  // String          - (Optional). A two-letter ISO 639-1 language code. If empty, commands will be applied to all users from the given scope, for whose language there are no dedicated commands
+     * ]
+     * </code>
+     *
+     * @link https://core.telegram.org/bots/api#deletemycommands
+     *
+     * @param array|null $params
+     *
+     * @return bool
+     */
+    public function deleteMyCommands(array $params = []): bool
+    {
+        return $this->post('deleteMyCommands', $params)->getResult();
+    }
+
+    /**
+     * Get the current list of the bot's commands.
+     *
+     * <code>
+     * $params = [
+     *      'scope'         => '',  // BotCommandScope - (Optional). A JSON-serialized object, describing scope of users. Defaults to BotCommandScopeDefault.
+     *      'language_code' => '',  // String          - (Optional). A two-letter ISO 639-1 language code or an empty string
+     * ]
+     * </code>
+     *
+     * @link https://core.telegram.org/bots/api#getmycommands
+     *
+     * @throws TelegramSDKException
+     * @return BotCommand[]
+     */
+    public function getMyCommands(array $params = []): array
+    {
+        return collect($this->get('getMyCommands', $params)->getResult())
+            ->mapInto(BotCommand::class)
+            ->all();
     }
 }

--- a/src/Methods/EditMessage.php
+++ b/src/Methods/EditMessage.php
@@ -3,13 +3,13 @@
 namespace Telegram\Bot\Methods;
 
 use Telegram\Bot\Exceptions\TelegramSDKException;
-use Telegram\Bot\Objects\InputMedia\InputMedia;
 use Telegram\Bot\Objects\Message;
 use Telegram\Bot\Objects\Poll;
 use Telegram\Bot\Traits\Http;
 
 /**
  * Class EditMessage.
+ *
  * @mixin Http
  */
 trait EditMessage
@@ -19,29 +19,20 @@ trait EditMessage
      *
      * <code>
      * $params = [
-     *   'chat_id'                  => '',
-     *   'message_id'               => '',
-     *   'inline_message_id'        => '',
-     *   'text'                     => '',
-     *   'parse_mode'               => '',
-     *   'disable_web_page_preview' => '',
-     *   'reply_markup'             => '',
-     * ];
+     *       'chat_id'                   => '',  // int|string - (Optional). Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format "@channelusername")
+     *       'message_id'                => '',  // int        - (Optional). Required if inline_message_id is not specified. Identifier of the sent message
+     *       'inline_message_id'         => '',  // string     - (Optional). Required if chat_id and message_id are not specified. Identifier of the inline message
+     *       'text'                      => '',  // string     - Required. New text of the message.
+     *       'parse_mode'                => '',  // string     - (Optional). Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.
+     *       'entities'                  => '',  // array      - (Optional). List of special entities that appear in the caption, which can be specified instead of parse_mode
+     *       'disable_web_page_preview'  => '',  // bool       - (Optional). Disables link previews for links in this message
+     *       'reply_markup'              => '',  // string     - (Optional). A JSON-serialized object for an inline keyboard.
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#editmessagetext
      *
-     * @param array $params [
-     *
-     * @var int|string $chat_id                  Optional. Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
-     * @var int        $message_id               Optional. Required if inline_message_id is not specified. Identifier of the sent message
-     * @var string     $inline_message_id        Optional. Required if chat_id and message_id are not specified. Identifier of the inline message
-     * @var string     $text                     Required. New text of the message.
-     * @var string     $parse_mode               Optional. Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.
-     * @var bool       $disable_web_page_preview Optional. Disables link previews for links in this message
-     * @var string     $reply_markup             Optional. A JSON-serialized object for an inline keyboard.
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
      *
@@ -56,30 +47,21 @@ trait EditMessage
 
     /**
      * Edit captions of messages sent by the bot or via the bot (for inline bots).
-     *
      * <code>
      * $params = [
-     *   'chat_id'                  => '',
-     *   'message_id'               => '',
-     *   'inline_message_id'        => '',
-     *   'caption'                  => '',
-     *   'parse_mode'               => '',
-     *   'reply_markup'             => '',
-     * ];
+     *       'chat_id'            => '',  // int|string - (Optional). Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format "@channelusername")
+     *       'message_id'         => '',  // int        - (Optional). Required if inline_message_id is not specified. Identifier of the sent message
+     *       'inline_message_id'  => '',  // string     - (Optional). Required if chat_id and message_id are not specified. Identifier of the inline message
+     *       'caption'            => '',  // string     - (Optional). New caption of the message
+     *       'parse_mode'         => '',  // string     - (Optional). Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in the media caption.
+     *       'caption_entities'   => '',  // array      - (Optional). List of special entities that appear in the caption, which can be specified instead of parse_mode
+     *       'reply_markup'       => '',  // string     - (Optional). A JSON-serialized object for an inline keyboard.
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#editmessagecaption
      *
-     * @param array $params [
-     *
-     * @var int|string $chat_id           Optional. Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
-     * @var int        $message_id        Optional. Required if inline_message_id is not specified. Identifier of the sent message
-     * @var string     $inline_message_id Optional. Required if chat_id and message_id are not specified. Identifier of the inline message
-     * @var string     $caption           Optional. New caption of the message
-     * @var string     $parse_mode        Optional. Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in the media caption.
-     * @var string     $reply_markup      Optional. A JSON-serialized object for an inline keyboard.
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
      *
@@ -97,25 +79,17 @@ trait EditMessage
      *
      * <code>
      * $params = [
-     *   'chat_id'                  => '',
-     *   'message_id'               => '',
-     *   'inline_message_id'        => '',
-     *   'media'                    => '',
-     *   'reply_markup'             => '',
-     * ];
+     *       'chat_id'            => '',  // int|string - (Optional). Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format "@channelusername")
+     *       'message_id'         => '',  // int        - (Optional). Required if inline_message_id is not specified. Identifier of the sent message
+     *       'inline_message_id'  => '',  // string     - (Optional). Required if chat_id and message_id are not specified. Identifier of the inline message
+     *       'media'              => '',  // InputMedia - Required. A JSON-serialized object for a new media content of the message
+     *       'reply_markup'       => '',  // string     - (Optional). A JSON-serialized object for an inline keyboard.
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#editmessagemedia
      *
-     * @param array $params [
-     *
-     * @var int|string $chat_id                  Optional. Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
-     * @var int        $message_id               Optional. Required if inline_message_id is not specified. Identifier of the sent message
-     * @var string     $inline_message_id        Optional. Required if chat_id and message_id are not specified. Identifier of the inline message
-     * @var InputMedia $media                    Required. A JSON-serialized object for a new media content of the message
-     * @var string     $reply_markup             Optional. A JSON-serialized object for an inline keyboard.
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
      *
@@ -133,23 +107,16 @@ trait EditMessage
      *
      * <code>
      * $params = [
-     *   'chat_id'                  => '',
-     *   'message_id'               => '',
-     *   'inline_message_id'        => '',
-     *   'reply_markup'             => '',
-     * ];
+     *       'chat_id'            => '',  // int|string - (Optional). Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format "@channelusername")
+     *       'message_id'         => '',  // int        - (Optional). Required if inline_message_id is not specified. Identifier of the sent message
+     *       'inline_message_id'  => '',  // string     - (Optional). Required if chat_id and message_id are not specified. Identifier of the inline message
+     *       'reply_markup'       => '',  // string     - (Optional). A JSON-serialized object for an inline keyboard.
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#editmessagereplymarkup
      *
-     * @param array $params [
-     *
-     * @var int|string $chat_id           Optional. Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
-     * @var int        $message_id        Optional. Required if inline_message_id is not specified. Identifier of the sent message
-     * @var string     $inline_message_id Optional. Required if chat_id and message_id are not specified. Identifier of the inline message
-     * @var string     $reply_markup      Optional. A JSON-serialized object for an inline keyboard.
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
      *
@@ -169,21 +136,15 @@ trait EditMessage
      *
      * <code>
      * $params = [
-     *   'chat_id'                  => '',
-     *   'message_id'               => '',
-     *   'reply_markup'             => '',
-     * ];
+     *       'chat_id'       => '',  // int|string - Required. Unique identifier for the target chat or username of the target channel (in the format "@channelusername")
+     *       'message_id'    => '',  // int        - Required. Identifier of the original message with the poll
+     *       'reply_markup'  => '',  // string     - (Optional). A JSON-serialized object for an inline keyboard.
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#stoppoll
      *
-     * @param array $params [
-     *
-     * @var int|string $chat_id           Required. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
-     * @var int        $message_id        Required. Identifier of the original message with the poll
-     * @var string     $reply_markup      Optional. A JSON-serialized object for an inline keyboard.
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
      *
@@ -208,28 +169,21 @@ trait EditMessage
      *
      * <code>
      * $params = [
-     *   'chat_id'                  => '',
-     *   'message_id'               => '',
-     * ];
+     *       'chat_id'     => '',  // int|string - Required. Unique identifier for the target chat or username of the target channel (in the format "@channelusername")
+     *       'message_id'  => '',  // int        - Required. Identifier of the message to delete.
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#deletemessage
      *
-     * @param array $params [
-     *
-     * @var int|string $chat_id           Required. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
-     * @var int        $message_id        Required. Identifier of the message to delete.
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
      *
-     * @return Message|bool
+     * @return bool
      */
     public function deleteMessage(array $params)
     {
-        $response = $this->post('deleteMessage', $params);
-
-        return $response->getResult();
+        return $this->post('deleteMessage', $params)->getResult();
     }
 }

--- a/src/Methods/Game.php
+++ b/src/Methods/Game.php
@@ -9,6 +9,7 @@ use Telegram\Bot\Traits\Http;
 
 /**
  * Class Game.
+ *
  * @mixin Http
  */
 trait Game
@@ -18,25 +19,19 @@ trait Game
      *
      * <code>
      * $params = [
-     *   'chat_id'                  => '',
-     *   'game_short_name'          => '',
-     *   'disable_notification'     => '',
-     *   'reply_to_message_id'      => '',
-     *   'reply_markup'             => '',
-     * ];
+     *       'chat_id'                      => '',  // int|string - Required. Unique identifier for the target chat or username of the target channel (in the format "@channelusername")
+     *       'game_short_name'              => '',  // string     - Required. Short name of the game, serves as the unique identifier for the game. Set up your games via Botfather.
+     *       'disable_notification'         => '',  // bool       - (Optional). Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.
+     *       'protect_content'              => '',  // bool       - (Optional). Protects the contents of the sent message from forwarding and saving
+     *       'reply_to_message_id'          => '',  // int        - (Optional). If the message is a reply, ID of the original message
+     *       'allow_sending_without_reply   => '',  // bool       - (Optional). Pass True, if the message should be sent even if the specified replied-to message is not found
+     *       'reply_markup'                 => '',  // string     - (Optional). A JSON-serialized object for an inline keyboard. If empty, one ‘Play game_title’ button will be shown. If not empty, the first button must launch the game.
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#sendgame
      *
-     * @param array $params [
-     *
-     * @var int|string $chat_id              Required. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
-     * @var string     $game_short_name      Required. Short name of the game, serves as the unique identifier for the game. Set up your games via Botfather.
-     * @var bool       $disable_notification Optional. Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.
-     * @var int        $reply_to_message_id  Optional. If the message is a reply, ID of the original message
-     * @var string     $reply_markup         Optional. A JSON-serialized object for an inline keyboard. If empty, one ‘Play game_title’ button will be shown. If not empty, the first button must launch the game.
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
      *
@@ -54,29 +49,19 @@ trait Game
      *
      * <code>
      * $params = [
-     *   'user_id'              => '',
-     *   'score'                => '',
-     *   'force'                => '',
-     *   'disable_edit_message' => '',
-     *   'chat_id'              => '',
-     *   'message_id'           => '',
-     *   'inline_message_id'    => '',
-     * ];
+     *       'user_id'               => '',  // int    - Required. User identifier
+     *       'score'                 => '',  // int    - Required. New score, must be non-negative
+     *       'force'                 => '',  // bool   - (Optional). Pass True, if the high score is allowed to decrease. This can be useful when fixing mistakes or banning cheaters
+     *       'disable_edit_message'  => '',  // bool   - (Optional). Pass True, if the game message should not be automatically edited to include the current scoreboard
+     *       'chat_id'               => '',  // int    - (Optional). Required if inline_message_id is not specified. Unique identifier for the target chat
+     *       'message_id'            => '',  // int    - (Optional). Required if inline_message_id is not specified. Identifier of the sent message
+     *       'inline_message_id'     => '',  // string - (Optional). Required if chat_id and message_id are not specified. Identifier of the inline message
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#setgamescore
      *
-     * @param array $params [
-     *
-     * @var int    $user_id              Required. User identifier
-     * @var int    $score                Required. New score, must be non-negative
-     * @var bool   $force                Optional. Pass True, if the high score is allowed to decrease. This can be useful when fixing mistakes or banning cheaters
-     * @var bool   $disable_edit_message Optional. Pass True, if the game message should not be automatically edited to include the current scoreboard
-     * @var int    $chat_id              Optional. Required if inline_message_id is not specified. Unique identifier for the target chat
-     * @var int    $message_id           Optional. Required if inline_message_id is not specified. Identifier of the sent message
-     * @var string $inline_message_id    Optional. Required if chat_id and message_id are not specified. Identifier of the inline message
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
      *
@@ -94,23 +79,16 @@ trait Game
      *
      * <code>
      * $params = [
-     *   'user_id'           => '',
-     *   'chat_id'           => '',
-     *   'message_id'        => '',
-     *   'inline_message_id' => '',
-     * ];
+     *       'user_id'            => '',  // int        - Required. Target user id
+     *       'chat_id'            => '',  // int|string - (Optional). Required if inline_message_id is not specified. Unique identifier for the target chat
+     *       'message_id'         => '',  // int        - (Optional). Required if inline_message_id is not specified. Identifier of the sent message
+     *       'inline_message_id'  => '',  // string     - (Optional). Required if chat_id and message_id are not specified. Identifier of the inline message
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#getgamehighscores
      *
-     * @param array $params [
-     *
-     * @var int        $user_id           Required. Target user id
-     * @var int|string $chat_id           Optional. Required if inline_message_id is not specified. Unique identifier for the target chat
-     * @var int        $message_id        Optional. Required if inline_message_id is not specified. Identifier of the sent message
-     * @var string     $inline_message_id Optional. Required if chat_id and message_id are not specified. Identifier of the inline message
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
      *
@@ -118,12 +96,8 @@ trait Game
      */
     public function getGameHighScores(array $params): array
     {
-        $response = $this->get('getGameHighScores', $params);
-
-        return collect($response->getResult())
-            ->map(function ($data) {
-                return new GameHighScore($data);
-            })
+        return collect($this->get('getGameHighScores', $params)->getResult())
+            ->mapInto(GameHighScore::class)
             ->all();
     }
 }

--- a/src/Methods/Get.php
+++ b/src/Methods/Get.php
@@ -10,6 +10,7 @@ use Telegram\Bot\Traits\Http;
 
 /**
  * Class Get.
+ *
  * @mixin Http
  */
 trait Get
@@ -34,23 +35,17 @@ trait Get
     /**
      * Returns a list of profile pictures for a user.
      *
-     * <code>
-     * $params = [
-     *   'user_id' => '',
-     *   'offset'  => '',
-     *   'limit'   => '',
-     * ];
-     * </code>
      *
      * @link https://core.telegram.org/bots/api#getuserprofilephotos
      *
-     * @param array $params [
-     *
-     * @var int $user_id Required. Unique identifier of the target user
-     * @var int $offset  Optional. Sequential number of the first photo to be returned. By default, all photos are returned.
-     * @var int $limit   Optional. Limits the number of photos to be retrieved. Values between 1—100 are accepted. Defaults to 100.
-     *
+     * <code>
+     * $params = [
+     *       'user_id' => '',  // int - Required. Unique identifier of the target user
+     *       'offset'  => '',  // int - (Optional). Sequential number of the first photo to be returned. By default, all photos are returned.
+     *       'limit'   => '',  // int - (Optional). Limits the number of photos to be retrieved. Values between 1—100 are accepted. Defaults to 100.
      * ]
+     * </code>
+     * @param array $params
      *
      * @throws TelegramSDKException
      *
@@ -66,11 +61,6 @@ trait Get
     /**
      * Returns basic info about a file and prepare it for downloading.
      *
-     * <code>
-     * $params = [
-     *   'file_id' => '',
-     * ];
-     * </code>
      *
      * The file can then be downloaded via the link
      * https://api.telegram.org/file/bot<token>/<file_path>,
@@ -78,11 +68,12 @@ trait Get
      *
      * @link https://core.telegram.org/bots/api#getFile
      *
-     * @param array $params [
-     *
-     * @var string $file_id Required. File identifier to get info about
-     *
+     * <code>
+     * $params = [
+     *       'file_id' => '',  // string - Required. File identifier to get info about
      * ]
+     * </code>
+     * @param array $params
      *
      * @throws TelegramSDKException
      *

--- a/src/Methods/Location.php
+++ b/src/Methods/Location.php
@@ -8,6 +8,7 @@ use Telegram\Bot\Traits\Http;
 
 /**
  * Class Location.
+ *
  * @mixin Http
  */
 trait Location
@@ -17,29 +18,24 @@ trait Location
      *
      * <code>
      * $params = [
-     *   'chat_id'              => '',
-     *   'latitude'             => '',
-     *   'longitude'            => '',
-     *   'live_period'          => '',
-     *   'disable_notification' => '',
-     *   'reply_to_message_id'  => '',
-     *   'reply_markup'         => '',
-     * ];
+     *       'chat_id'                     => '',  // int|string - Required. Unique identifier for the target chat or username of the target channel (in the format "@channelusername")
+     *       'latitude'                    => '',  // float      - Required. Latitude of location
+     *       'longitude'                   => '',  // float      - Required. Longitude of location
+     *       'horizontal_accuracy          => '',  // float      - (Optional). The radius of uncertainty for the location, measured in meters; 0-1500
+     *       'live_period'                 => '',  // int        - (Optional). Period in seconds for which the location will be updated (see Live Locations, should be between 60 and 86400.
+     *       'heading'                     => '',  // int        - (Optional). For live locations, a direction in which the user is moving, in degrees. Must be between 1 and 360 if specified.
+     *       'proximity_alert_radius'      => '',  // int        - (Optional). For live locations, a maximum distance for proximity alerts about approaching another chat member, in meters. Must be between 1 and 100000 if specified.
+     *       'disable_notification'        => '',  // bool       - (Optional). Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.
+     *       'protect_content'             => '',  // bool       - (Optional). Protects the contents of the sent message from forwarding and saving
+     *       'reply_to_message_id'         => '',  // int        - (Optional). If the message is a reply, ID of the original message
+     *       'allow_sending_without_reply' => '',  // bool       - (Optional). Pass True, if the message should be sent even if the specified replied-to message is not found
+     *       'reply_markup'                => '',  // string     - (Optional). Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#sendlocation
      *
-     * @param array    $params               [
-     *
-     * @var int|string $chat_id              Required. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
-     * @var float      $latitude             Required. Latitude of location
-     * @var float      $longitude            Required. Longitude of location
-     * @var int        $live_period          Optional. Period in seconds for which the location will be updated (see Live Locations, should be between 60 and 86400.
-     * @var bool       $disable_notification Optional. Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.
-     * @var int        $reply_to_message_id  Optional. If the message is a reply, ID of the original message
-     * @var string     $reply_markup         Optional. Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
      *
@@ -57,27 +53,21 @@ trait Location
      *
      * <code>
      * $params = [
-     *   'chat_id'              => '',
-     *   'message_id'           => '',
-     *   'inline_message_id'    => '',
-     *   'latitude'             => '',
-     *   'longitude'            => '',
-     *   'reply_markup'         => '',
-     * ];
+     *       'chat_id'                => '',  // int|string - (Optional|Required). Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format "@channelusername")
+     *       'message_id'             => '',  // int        - (Optional|Required). Required if inline_message_id is not specified. Identifier of the sent message
+     *       'inline_message_id'      => '',  // string     - (Optional|Required). Required if chat_id and message_id are not specified. Identifier of the inline message
+     *       'latitude'               => '',  // float      - Required. Latitude of location
+     *       'longitude'              => '',  // float      - Required. Longitude of location
+     *       'horizontal_accuracy     => '',  // float      - (Optional). The radius of uncertainty for the location, measured in meters; 0-1500
+     *       'heading'                => '',  // int        - (Optional). For live locations, a direction in which the user is moving, in degrees. Must be between 1 and 360 if specified.
+     *       'proximity_alert_radius' => '',  // int        - (Optional). For live locations, a maximum distance for proximity alerts about approaching another chat member, in meters. Must be between 1 and 100000 if specified.
+     *       'reply_markup'           => '',  // string     - (Optional). A JSON-serialized object for a new inline keyboard.
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#editmessagelivelocation
      *
-     * @param array    $params            [
-     *
-     * @var int|string $chat_id           (Optional|Required). Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
-     * @var int        $message_id        (Optional|Required). Required if inline_message_id is not specified. Identifier of the sent message
-     * @var string     $inline_message_id (Optional|Required). Required if chat_id and message_id are not specified. Identifier of the inline message
-     * @var float      $latitude          Required. Latitude of location
-     * @var float      $longitude         Required. Longitude of location
-     * @var string     $reply_markup      Optional. A JSON-serialized object for a new inline keyboard.
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
      *
@@ -95,23 +85,16 @@ trait Location
      *
      * <code>
      * $params = [
-     *   'chat_id'              => '',
-     *   'message_id'           => '',
-     *   'inline_message_id'    => '',
-     *   'reply_markup'         => '',
-     * ];
+     *       'chat_id'            => '',  // int|string - (Optional|Required). Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format "@channelusername")
+     *       'message_id'         => '',  // int        - (Optional|Required). Required if inline_message_id is not specified. Identifier of the sent message
+     *       'inline_message_id'  => '',  // string     - (Optional|Required). Required if chat_id and message_id are not specified. Identifier of the inline message
+     *       'reply_markup'       => '',  // string     - (Optional). A JSON-serialized object for a new inline keyboard.
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#stopmessagelivelocation
      *
-     * @param array    $params            [
-     *
-     * @var int|string $chat_id           (Optional|Required). Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
-     * @var int        $message_id        (Optional|Required). Required if inline_message_id is not specified. Identifier of the sent message
-     * @var string     $inline_message_id (Optional|Required). Required if chat_id and message_id are not specified. Identifier of the inline message
-     * @var string     $reply_markup      Optional. A JSON-serialized object for a new inline keyboard.
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
      *

--- a/src/Methods/Message.php
+++ b/src/Methods/Message.php
@@ -3,12 +3,12 @@
 namespace Telegram\Bot\Methods;
 
 use Telegram\Bot\Exceptions\TelegramSDKException;
-use Telegram\Bot\FileUpload\InputFile;
 use Telegram\Bot\Objects\Message as MessageObject;
 use Telegram\Bot\Traits\Http;
 
 /**
  * Class Message.
+ *
  * @mixin Http
  */
 trait Message
@@ -18,31 +18,24 @@ trait Message
      *
      * <code>
      * $params = [
-     *   'chat_id'                  => '',
-     *   'text'                     => '',
-     *   'parse_mode'               => '',
-     *   'disable_web_page_preview' => '',
-     *   'disable_notification'     => '',
-     *   'reply_to_message_id'      => '',
-     *   'reply_markup'             => '',
-     * ];
+     *       'chat_id'                     => '',  // int|string - Required. Unique identifier for the target chat or username of the target channel (in the format "@channelusername")
+     *       'text'                        => '',  // string     - Required. Text of the message to be sent
+     *       'parse_mode'                  => '',  // string     - (Optional). Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.
+     *       'entities'                    => '',  // array      - (Optional). List of special entities that appear in the caption, which can be specified instead of parse_mode
+     *       'disable_web_page_preview'    => '',  // bool       - (Optional). Disables link previews for links in this message
+     *       'protect_content'             => '',  // bool       - (Optional). Protects the contents of the sent message from forwarding and saving
+     *       'disable_notification'        => '',  // bool       - (Optional). Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.
+     *       'reply_to_message_id'         => '',  // int        - (Optional). If the message is a reply, ID of the original message
+     *       'allow_sending_without_reply' => '',  // bool       - (Optional). Pass True, if the message should be sent even if the specified replied-to message is not found
+     *       'reply_markup'                => '',  // object     - (Optional). One of either InlineKeyboardMarkup|ReplyKeyboardMarkup|ReplyKeyboardRemove|ForceReply for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#sendmessage
      *
-     * @param array    $params                   [
+     * @param array $params
      *
-     * @var int|string $chat_id                  Required. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
-     * @var string     $text                     Required. Text of the message to be sent
-     * @var string     $parse_mode               Optional. Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.
-     * @var bool       $disable_web_page_preview Optional. Disables link previews for links in this message
-     * @var bool       $disable_notification     Optional. Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.
-     * @var int        $reply_to_message_id      Optional. If the message is a reply, ID of the original message
-     * @var string     $reply_markup             Optional. Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
-     *
-     * ]
-     *
-     * @throws \Telegram\Bot\Exceptions\TelegramSDKException
+     * @throws TelegramSDKException
      *
      * @return MessageObject
      */
@@ -58,23 +51,17 @@ trait Message
      *
      * <code>
      * $params = [
-     *   'chat_id'              => '',
-     *   'from_chat_id'         => '',
-     *   'disable_notification' => '',
-     *   'message_id'           => '',
-     * ];
+     *       'chat_id'               => '',  // int|string - Required. Unique identifier for the target chat or username of the target channel (in the format "@channelusername")
+     *       'from_chat_id'          => '',  // int        - Required. Unique identifier for the chat where the original message was sent (or channel username in the format "@channelusername")
+     *       'disable_notification'  => '',  // bool       - (Optional). Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.
+     *       'protect_content'       => '',  // bool       - (Optional). Protects the contents of the sent message from forwarding and saving
+     *       'message_id'            => '',  // int        - Required. Message identifier in the chat specified in from_chat_id
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#forwardmessage
      *
-     * @param array    $params               [
-     *
-     * @var int|string $chat_id              Required. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
-     * @var int        $from_chat_id         Required. Unique identifier for the chat where the original message was sent (or channel username in the format @channelusername)
-     * @var bool       $disable_notification Optional. Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.
-     * @var int        $message_id           Required. Message identifier in the chat specified in from_chat_id
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
      *
@@ -88,33 +75,62 @@ trait Message
     }
 
     /**
+     * Copy messages of any kind.
+     *
+     * The method is analogous to the method forwardMessages, but the copied message doesn't have a link to the original message.
+     *
+     * <code>
+     * $params = [
+     *       'chat_id'                       => '',  // int|string - Required. Unique identifier for the target chat or username of the target channel (in the format "@channelusername")
+     *       'from_chat_id'                  => '',  // int        - Required. Unique identifier for the chat where the original message was sent (or channel username in the format "@channelusername")
+     *       'message_id'                    => '',  // int        - Required. Message identifier in the chat specified in from_chat_id
+     *       'caption'                       => '',  // string     - (Optional). New caption for media, 0-1024 characters after entities parsing. If not specified, the original caption is kept
+     *       'parse_mode'                    => '',  // string     - (Optional). Mode for parsing entities in the new caption. See formatting options for more details.
+     *       'caption_entities'              => '',  // array      - (Optional). List of special entities that appear in the new caption, which can be specified instead of parse_mode
+     *       'disable_notification'          => '',  // bool       - (Optional). Sends the message silently. Users will receive a notification with no sound.
+     *       'protect_content'               => '',  // bool       - (Optional). Protects the contents of the sent message from forwarding and saving
+     *       'reply_to_message_id'           => '',  // int        - (Optional). If the message is a reply, ID of the original message
+     *       'allow_sending_without_reply'   => '',  // bool       - (Optional). Pass True, if the message should be sent even if the specified replied-to message is not found
+     *       'reply_markup'                  => '',  // string     - (Optional). Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+     * ]
+     * </code>
+     *
+     * @link https://core.telegram.org/bots/api#copymessage
+     *
+     * @param array $params
+     *
+     * @throws TelegramSDKException
+     *
+     * @return MessageObject
+     */
+    public function copyMessage(array $params): MessageObject
+    {
+        $response = $this->post('copyMessage', $params);
+
+        return new MessageObject($response->getDecodedBody());
+    }
+
+    /**
      * Send Photo.
      *
      * <code>
      * $params = [
-     *   'chat_id'              => '',
-     *   'photo'                => InputFile::create($resourceOrFile, $filename),
-     *   'caption'              => '',
-     *   'parse_mode'           => '',
-     *   'disable_notification' => '',
-     *   'reply_to_message_id'  => '',
-     *   'reply_markup'         => '',
-     * ];
+     *       'chat_id'                     => '',                      // int|string       - Required. Unique identifier for the target chat or username of the target channel (in the format "@channelusername")
+     *       'photo'                       => InputFile::file($file),  // InputFile|string - Required. Photo to send. Pass a file_id as String to send a photo that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get a photo from the Internet, or upload a new photo using multipart/form-data.
+     *       'caption'                     => '',                      // string           - (Optional). Photo caption (may also be used when resending photos by file_id), 0-200 characters
+     *       'parse_mode'                  => '',                      // string           - (Optional). Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in the media caption.
+     *       'caption_entities'            => '',                      // array            - (Optional). List of special entities that appear in the caption, which can be specified instead of parse_mode
+     *       'disable_notification'        => '',                      // bool             - (Optional). Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.
+     *       'protect_content'             => '',                      // bool             - (Optional). Protects the contents of the sent message from forwarding and saving
+     *       'reply_to_message_id'         => '',                      // int              - (Optional). If the message is a reply, ID of the original message
+     *       'allow_sending_without_reply' => '',                      // bool       - (Optional). Pass True, if the message should be sent even if the specified replied-to message is not found
+     *       'reply_markup'                => '',                      // string           - (Optional). Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#sendphoto
      *
-     * @param array          $params               [
-     *
-     * @var int|string       $chat_id              Required. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
-     * @var InputFile|string $photo                Required. Photo to send. Pass a file_id as String to send a photo that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get a photo from the Internet, or upload a new photo using multipart/form-data.
-     * @var string           $caption              Optional. Photo caption (may also be used when resending photos by file_id), 0-200 characters
-     * @var string           $parse_mode           Optional. Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in the media caption.
-     * @var bool             $disable_notification Optional. Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.
-     * @var int              $reply_to_message_id  Optional. If the message is a reply, ID of the original message
-     * @var string           $reply_markup         Optional. Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
      *
@@ -132,37 +148,26 @@ trait Message
      *
      * <code>
      * $params = [
-     *   'chat_id'              => '',
-     *   'audio'                => InputFile::create($resourceOrFile, $filename),
-     *   'caption'              => '',
-     *   'parse_mode'           => '',
-     *   'duration'             => '',
-     *   'performer'            => '',
-     *   'title'                => '',
-     *   'thumb'                => '',
-     *   'disable_notification' => '',
-     *   'reply_to_message_id'  => '',
-     *   'reply_markup'         => '',
-     * ];
-     * </code>
+     *       'chat_id'                     => '',                      // int|string       - Required. Unique identifier for the target chat or username of the target channel (in the format "@channelusername")
+     *       'audio'                       => InputFile::file($file),  // InputFile|string - Required. Audio file to send. Pass a file_id as String to send an audio file that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get an audio file from the Internet, or upload a new one using multipart/form-data.
+     *       'caption'                     => '',                      // string           - (Optional). Audio caption, 0-200 characters
+     *       'parse_mode'                  => '',                      // string           - (Optional). Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in the media caption.
+     *       'caption_entities'            => '',                      // array            - (Optional). List of special entities that appear in the caption, which can be specified instead of parse_mode
+     *       'duration'                    => '',                      // int              - (Optional). Duration of the audio in seconds
+     *       'performer'                   => '',                      // string           - (Optional). Performer
+     *       'title'                       => '',                      // string           - (Optional). Track name
+     *       'thumb'                       => InputFile::file($file),  // InputFile|string - (Optional). Thumbnail can be ignored if thumbnail generation for the file is supported server-side. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should not exceed 320. Thumbnails can't be reused and can be only uploaded as a new file.
+     *       'disable_notification'        => '',                      // bool             - (Optional). Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.
+     *       'protect_content'             => '',                      // bool             - (Optional). Protects the contents of the sent message from forwarding and saving
+     *       'reply_to_message_id'         => '',                      // int              - (Optional). If the message is a reply, ID of the original message
+     *       'allow_sending_without_reply' => '',                      // bool             - (Optional). Pass True, if the message should be sent even if the specified replied-to message is not found
+     *       'reply_markup'                => '',                      // string           - (Optional). Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+     * ]
      *
      * @link https://core.telegram.org/bots/api#sendaudio
+     * </code>
      *
-     * @param array          $params               [
-     *
-     * @var int|string       $chat_id              Required. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
-     * @var InputFile|string $audio                Required. Audio file to send. Pass a file_id as String to send an audio file that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get an audio file from the Internet, or upload a new one using multipart/form-data.
-     * @var string           $caption              Optional. Audio caption, 0-200 characters
-     * @var string           $parse_mode           Optional. Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in the media caption.
-     * @var int              $duration             Optional. Duration of the audio in seconds
-     * @var string           $performer            Optional. Performer
-     * @var string           $title                Optional. Track name
-     * @var InputFile|string $thumb                Optional. Thumbnail of the file sent. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail‘s width and height should not exceed 90. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can’t be reused and can be only uploaded as a new file, so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using multipart/form-data under <file_attach_name>
-     * @var bool             $disable_notification Optional. Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.
-     * @var int              $reply_to_message_id  Optional. If the message is a reply, ID of the original message
-     * @var string           $reply_markup         Optional. Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
      *
@@ -180,30 +185,24 @@ trait Message
      *
      * <code>
      * $params = [
-     *   'chat_id'              => '',
-     *   'document'             => InputFile::create($resourceOrFile, $filename),
-     *   'thumb'                => '',
-     *   'caption'              => '',
-     *   'parse_mode'           => '',
-     *   'disable_notification' => '',
-     *   'reply_to_message_id'  => '',
-     *   'reply_markup'         => '',
-     * ];
+     *       'chat_id'                         => '',                      // int|string       - Required. Unique identifier for the target chat or username of the target channel (in the format "@channelusername")
+     *       'document'                        => InputFile::file($file),  // InputFile|string - Required. File to send. Pass a file_id as String to send a file that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get a file from the Internet, or upload a new one using multipart/form-data.
+     *       'thumb'                           => InputFile::file($file),  // InputFile|string - (Optional). Thumbnail can be ignored if thumbnail generation for the file is supported server-side. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should not exceed 320. Thumbnails can't be reused and can be only uploaded as a new file.
+     *       'caption'                         => '',                      // string           - (Optional). Document caption (may also be used when resending documents by file_id), 0-200 characters
+     *       'parse_mode'                      => '',                      // string           - (Optional). Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in the media caption.
+     *       'caption_entities                 => '',                      // array            - (Optional). List of special entities that appear in the caption, which can be specified instead of parse_mode
+     *       'disable_content_type_detection'  => '',                      // bool             - (Optional). Disables automatic server-side content type detection for files uploaded using multipart/form-data
+     *       'disable_notification'            => '',                      // bool             - (Optional). Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.
+     *       'protect_content'                 => '',                      // bool             - (Optional). Protects the contents of the sent message from forwarding and saving
+     *       'reply_to_message_id'             => '',                      // int              - (Optional). If the message is a reply, ID of the original message
+     *       'allow_sending_without_reply      => '',                      // bool             - (Optional). Pass True, if the message should be sent even if the specified replied-to message is not found
+     *       'reply_markup'                    => '',                      // string           - (Optional). Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#senddocument
      *
-     * @param array          $params               [
-     *
-     * @var int|string       $chat_id              Required. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
-     * @var InputFile|string $document             Required. File to send. Pass a file_id as String to send a file that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get a file from the Internet, or upload a new one using multipart/form-data.
-     * @var string           $caption              Optional. Document caption (may also be used when resending documents by file_id), 0-200 characters
-     * @var string           $parse_mode           Optional. Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in the media caption.
-     * @var bool             $disable_notification Optional. Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.
-     * @var int              $reply_to_message_id  Optional. If the message is a reply, ID of the original message
-     * @var string           $reply_markup         Optional. Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
      *
@@ -221,39 +220,28 @@ trait Message
      *
      * <code>
      * $params = [
-     *   'chat_id'              => '',
-     *   'video'                => InputFile::create($resourceOrFile, $filename),
-     *   'duration'             => '',
-     *   'width'                => '',
-     *   'height'               => '',
-     *   'thumb'                => '',
-     *   'caption'              => '',
-     *   'parse_mode'           => '',
-     *   'supports_streaming'   => '',
-     *   'disable_notification' => '',
-     *   'reply_to_message_id'  => '',
-     *   'reply_markup'         => '',
-     * ];
+     *       'chat_id'                     => '',                      // int|string       - Required. Unique identifier for the target chat or username of the target channel (in the format "@channelusername")
+     *       'video'                       => InputFile::file($file),  // InputFile|string - Required. Video to send. Pass a file_id as String to send a video that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get a video from the Internet, or upload a new video using multipart/form-data.
+     *       'duration'                    => '',                      // int              - (Optional). Duration of sent video in seconds
+     *       'width'                       => '',                      // int              - (Optional). Video width
+     *       'height'                      => '',                      // int              - (Optional). Video height
+     *       'thumb'                       => InputFile::file($file),  // InputFile|string - (Optional). Thumbnail can be ignored if thumbnail generation for the file is supported server-side. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should not exceed 320. Thumbnails can't be reused and can be only uploaded as a new file.
+     *       'caption'                     => '',                      // string           - (Optional). Video caption (may also be used when resending videos by file_id), 0-200 characters.
+     *       'parse_mode'                  => '',                      // string           - (Optional). Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in the media caption.
+     *       'caption_entities'            => '',                      // array            - (Optional). List of special entities that appear in the caption, which can be specified instead of parse_mode
+     *       'supports_streaming'          => '',                      // bool             - (Optional). Pass True, if the uploaded video is suitable for streaming
+     *       'disable_notification'        => '',                      // bool             - (Optional). Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.
+     *       'protect_content'             => '',                      // bool             - (Optional). Protects the contents of the sent message from forwarding and saving
+     *       'reply_to_message_id'         => '',                      // int              - (Optional). If the message is a reply, ID of the original message
+     *       'allow_sending_without_reply' => '',                      // bool             - (Optional). Pass True, if the message should be sent even if the specified replied-to message is not found
+     *       'reply_markup'                => '',                      // string           - (Optional). Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+     * ]
      * </code>
      *
-     * @see  sendDocument
      * @link https://core.telegram.org/bots/api#sendvideo
+     * @see  sendDocument
      *
-     * @param array          $params               [
-     *
-     * @var int|string       $chat_id              Required. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
-     * @var InputFile|string $video                Required. Video to send. Pass a file_id as String to send a video that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get a video from the Internet, or upload a new video using multipart/form-data.
-     * @var int              $duration             Optional. Duration of sent video in seconds
-     * @var int              $width                Optional. Video width
-     * @var int              $height               Optional. Video height
-     * @var string           $caption              Optional  Video caption (may also be used when resending videos by file_id), 0-200 characters.
-     * @var string           $parse_mode           Optional. Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in the media caption.
-     * @var bool             $supports_streaming   Optional. Pass True, if the uploaded video is suitable for streaming
-     * @var bool             $disable_notification Optional. Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.
-     * @var int              $reply_to_message_id  Optional. If the message is a reply, ID of the original message
-     * @var string           $reply_markup         Optional. Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
      *
@@ -271,37 +259,26 @@ trait Message
      *
      * <code>
      * $params = [
-     *   'chat_id'              => '',
-     *   'animation'            => InputFile::create($resourceOrFile, $filename),
-     *   'duration'             => '',
-     *   'width'                => '',
-     *   'height'               => '',
-     *   'thumb'                => '',
-     *   'caption'              => '',
-     *   'parse_mode'           => '',
-     *   'disable_notification' => '',
-     *   'reply_to_message_id'  => '',
-     *   'reply_markup'         => '',
-     * ];
+     *       'chat_id'                       => '',                      // int|string       - Required. Unique identifier for the target chat or username of the target channel (in the format "@channelusername")
+     *       'animation'                     => InputFile::file($file),  // InputFile|string - Required. Animation to send. Pass a file_id as String to send an animation that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get an animation from the Internet, or upload a new animation using multipart/form-data.
+     *       'duration'                      => '',                      // int              - (Optional). Duration of sent animation in seconds
+     *       'width'                         => '',                      // int              - (Optional). Animation width
+     *       'height'                        => '',                      // int              - (Optional). Animation height
+     *       'thumb'                         => InputFile::file($file),  // InputFile|string - (Optional). Thumbnail can be ignored if thumbnail generation for the file is supported server-side. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should not exceed 320. Thumbnails can't be reused and can be only uploaded as a new file.
+     *       'caption'                       => '',                      // string           - (Optional). Document caption (may also be used when resending documents by file_id), 0-200 characters
+     *       'parse_mode'                    => '',                      // string           - (Optional). Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in the media caption.
+     *       'caption_entities'              => '',                      // array            - (Optional). List of special entities that appear in the caption, which can be specified instead of parse_mode
+     *       'disable_notification'          => '',                      // bool             - (Optional). Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.
+     *       'protect_content'               => '',                      // bool             - (Optional). Protects the contents of the sent message from forwarding and saving
+     *       'reply_to_message_id'           => '',                      // int              - (Optional). If the message is a reply, ID of the original message
+     *       'allow_sending_without_reply'   => '',                      // bool             - (Optional). Pass True, if the message should be sent even if the specified replied-to message is not found
+     *       'reply_markup'                  => '',                      // string           - (Optional). Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#sendanimation
      *
-     * @param array          $params               [
-     *
-     * @var int|string       $chat_id              Required. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
-     * @var InputFile|string $animation            Required. Animation to send. Pass a file_id as String to send an animation that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get an animation from the Internet, or upload a new animation using multipart/form-data.
-     * @var int              $duration             Optional. Duration of sent animation in seconds
-     * @var int              $width                Optional. Animation width
-     * @var int              $height               Optional. Animation height
-     * @var InputFile|string $thumb                Optional. Thumbnail of the file sent. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail‘s width and height should not exceed 90. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can’t be reused and can be only uploaded as a new file, so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using multipart/form-data under <file_attach_name>
-     * @var string           $caption              Optional. Document caption (may also be used when resending documents by file_id), 0-200 characters
-     * @var string           $parse_mode           Optional. Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in the media caption.
-     * @var bool             $disable_notification Optional. Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.
-     * @var int              $reply_to_message_id  Optional. If the message is a reply, ID of the original message
-     * @var string           $reply_markup         Optional. Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
      *
@@ -319,31 +296,23 @@ trait Message
      *
      * <code>
      * $params = [
-     *   'chat_id'              => '',
-     *   'voice'                => InputFile::create($resourceOrFile, $filename),
-     *   'caption'              => '',
-     *   'parse_mode'           => '',
-     *   'duration'             => '',
-     *   'disable_notification' => '',
-     *   'reply_to_message_id'  => '',
-     *   'reply_markup'         => '',
-     * ];
+     *       'chat_id'                      => '',                       // int|string       - Required. Unique identifier for the target chat or username of the target channel (in the format "@channelusername")
+     *       'voice'                        => InputFile::file($file),   // InputFile|string - Required. Audio file to send. Pass a file_id as String to send a file that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get a file from the Internet, or upload a new one using multipart/form-data.
+     *       'caption'                      => '',                       // string           - (Optional). Voice message caption, 0-200 characters
+     *       'parse_mode'                   => '',                       // string           - (Optional). Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in the media caption.
+     *       'caption_entities'             => '',                       // array            - (Optional). List of special entities that appear in the caption, which can be specified instead of parse_mode
+     *       'duration'                     => '',                       // int              - (Optional). Duration of the voice message in seconds
+     *       'disable_notification'         => '',                       // bool             - (Optional). Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.
+     *       'protect_content'              => '',                       // bool             - (Optional). Protects the contents of the sent message from forwarding and saving
+     *       'reply_to_message_id'          => '',                       // int              - (Optional). If the message is a reply, ID of the original message
+     *       'allow_sending_without_reply'  => '',                       // bool             - (Optional). Pass True, if the message should be sent even if the specified replied-to message is not found
+     *       'reply_markup'                 => '',                       // string           - (Optional). Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#sendvoice
      *
-     * @param array          $params               [
-     *
-     * @var int|string       $chat_id              Required. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
-     * @var InputFile|string $voice                Required. Audio file to send. Pass a file_id as String to send a file that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get a file from the Internet, or upload a new one using multipart/form-data.
-     * @var string           $caption              Optional. Voice message caption, 0-200 characters
-     * @var string           $parse_mode           Optional. Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in the media caption.
-     * @var int              $duration             Optional. Duration of the voice message in seconds
-     * @var bool             $disable_notification Optional. Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.
-     * @var int              $reply_to_message_id  Optional. If the message is a reply, ID of the original message
-     * @var string           $reply_markup         Optional. Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
      *
@@ -361,31 +330,22 @@ trait Message
      *
      * <code>
      * $params = [
-     *   'chat_id'              => '',
-     *   'video_note'           => InputFile::create($resourceOrFile, $filename),
-     *   'duration'             => '',
-     *   'length'               => '',
-     *   'thumb'                => '',
-     *   'disable_notification' => '',
-     *   'reply_to_message_id'  => '',
-     *   'reply_markup'         => '',
-     * ];
+     *       'chat_id'                       => '',                      // int|string       - Required. Unique identifier for the target chat or username of the target channel (in the format "@channelusername")
+     *       'video_note'                    => InputFile::file($file),  // InputFile|string - Required. Video note to send. Pass a file_id as String to send a video note that exists on the Telegram servers (recommended) or upload a new video using multipart/form-data.
+     *       'duration'                      => '',                      // int              - (Optional). Duration of sent video in seconds
+     *       'length'                        => '',                      // int              - (Optional). Video width and height
+     *       'thumb'                         => InputFile::file($file),  // InputFile|string - (Optional). Thumbnail can be ignored if thumbnail generation for the file is supported server-side. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should not exceed 320. Thumbnails can't be reused and can be only uploaded as a new file.
+     *       'disable_notification'          => '',                      // bool             - (Optional). Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.
+     *       'protect_content'               => '',                      // bool             - (Optional). Protects the contents of the sent message from forwarding and saving
+     *       'reply_to_message_id'           => '',                      // int              - (Optional). If the message is a reply, ID of the original message
+     *       'allow_sending_without_reply    => '',                      // bool             - (Optional). Pass True, if the message should be sent even if the specified replied-to message is not found
+     *       'reply_markup'                  => '',                      // string           - (Optional). Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#sendvideonote
      *
-     * @param array          $params               [
-     *
-     * @var int|string       $chat_id              Required. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
-     * @var InputFile|string $video_note           Required. Video note to send. Pass a file_id as String to send a video note that exists on the Telegram servers (recommended) or upload a new video using multipart/form-data.
-     * @var int              $duration             Optional. Duration of sent video in seconds
-     * @var int              $length               Optional. Video width and height
-     * @var InputFile|string $thumb                Optional. Thumbnail of the file sent. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail‘s width and height should not exceed 90. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can’t be reused and can be only uploaded as a new file, so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using multipart/form-data under <file_attach_name>
-     * @var bool             $disable_notification Optional. Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.
-     * @var int              $reply_to_message_id  Optional. If the message is a reply, ID of the original message
-     * @var string           $reply_markup         Optional. Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
      *
@@ -399,28 +359,22 @@ trait Message
     }
 
     /**
-     * Send a group of photos or videos as an album.
+     * Send a group of photos, audio, documents or videos as an album.
      *
      * <code>
      * $params = [
-     *   'chat_id'              => '',
-     *   'media'                => [],
-     *   'disable_notification' => '',
-     *   'reply_to_message_id'  => '',
-     * ];
+     *       'chat_id'                       => '',  // int|string    - Required. Unique identifier for the target chat or username of the target channel (in the format "@channelusername")
+     *       'media'                         => [],  // array         - Required. A JSON-serialized array describing messages to be sent, must include 2-10 items. Array of InputMediaAudio, InputMediaDocument, InputMediaPhoto and InputMediaVideo
+     *       'disable_notification'          => '',  // bool          - (Optional). Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.
+     *       'protect_content'               => '',  // bool          - (Optional). Protects the contents of the sent messages from forwarding and saving
+     *       'reply_to_message_id'           => '',  // int           - (Optional). If the message is a reply, ID of the original message
+     *       'allow_sending_without_reply    => '',  // bool          - (Optional). Pass True, if the message should be sent even if the specified replied-to message is not found
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#sendmediagroup
      *
-     * @param array    $params               [
-     *
-     * @var int|string $chat_id              Required. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
-     * @var array      $media                Required. A JSON-serialized array describing photos and videos to be sent, must include 2–10 items
-     * @var int        $duration             Optional. Duration of sent video in seconds
-     * @var bool       $disable_notification Optional. Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.
-     * @var int        $reply_to_message_id  Optional. If the message is a reply, ID of the original message
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
      *
@@ -439,35 +393,26 @@ trait Message
      *
      * <code>
      * $params = [
-     *   'chat_id'              => '',
-     *   'latitude'             => '',
-     *   'longitude'            => '',
-     *   'title'                => '',
-     *   'address'              => '',
-     *   'foursquare_id'        => '',
-     *   'foursquare_type'      => '',
-     *   'disable_notification' => '',
-     *   'reply_to_message_id'  => '',
-     *   'reply_markup'         => '',
-     * ];
+     *       'chat_id'                    => '',  // int|string - Required. Unique identifier for the target chat or username of the target channel (in the format "@channelusername")
+     *       'latitude'                   => '',  // float      - Required. Latitude of the venue
+     *       'longitude'                  => '',  // float      - Required. Longitude of the venue
+     *       'title'                      => '',  // string     - Required. Name of the venue
+     *       'address'                    => '',  // string     - Required. Address of the venue
+     *       'foursquare_id'              => '',  // string     - (Optional). Foursquare identifier of the venue
+     *       'foursquare_type'            => '',  // string     - (Optional). Foursquare type of the venue, if known. (For example, “arts_entertainment/default”, “arts_entertainment/aquarium” or “food/icecream”.)
+     *       'google_place_id'            => '',  // string     - (Optional). Google Places identifier of the venue
+     *       'google_place_type'          => '',  // string     - (Optional). Google Places type of the venue.
+     *       'disable_notification'       => '',  // bool       - (Optional). Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.
+     *       'protect_content'            => '',  // bool       - (Optional). Protects the contents of the sent message from forwarding and saving
+     *       'reply_to_message_id'        => '',  // int        - (Optional). If the message is a reply, ID of the original message
+     *       'allow_sending_without_reply => '', // bool        - (Optional). Pass True, if the message should be sent even if the specified replied-to message is not found
+     *       'reply_markup'               => '',  // string     - (Optional). Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#sendvenue
      *
-     * @param array    $params               [
-     *
-     * @var int|string $chat_id              Required. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
-     * @var float      $latitude             Required. Latitude of the venue
-     * @var float      $longitude            Required. Longitude of the venue
-     * @var string     $title                Required. Name of the venue
-     * @var string     $address              Required. Address of the venue
-     * @var string     $foursquare_id        Optional. Foursquare identifier of the venue
-     * @var string     $foursquare_type      Optional. Foursquare type of the venue, if known. (For example, “arts_entertainment/default”, “arts_entertainment/aquarium” or “food/icecream”.)
-     * @var bool       $disable_notification Optional. Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.
-     * @var int        $reply_to_message_id  Optional. If the message is a reply, ID of the original message
-     * @var string     $reply_markup         Optional. Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
      *
@@ -485,31 +430,22 @@ trait Message
      *
      * <code>
      * $params = [
-     *   'chat_id'              => '',
-     *   'phone_number'         => '',
-     *   'first_name'           => '',
-     *   'last_name'            => '',
-     *   'vcard'                => '',
-     *   'disable_notification' => '',
-     *   'reply_to_message_id'  => '',
-     *   'reply_markup'         => '',
-     * ];
+     *       'chat_id'                      => '',  // int|string - Required. Unique identifier for the target chat or username of the target channel (in the format "@channelusername")
+     *       'phone_number'                 => '',  // string     - Required. Contact's phone number
+     *       'first_name'                   => '',  // string     - Required. Contact's first name
+     *       'last_name'                    => '',  // string     - Required. Contact's last name
+     *       'vcard'                        => '',  // string     - (Optional). Additional data about the contact in the form of a vCard, 0-2048 bytes
+     *       'disable_notification'         => '',  // bool       - (Optional). Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.
+     *       'protect_content'              => '',  // bool       - (Optional). Protects the contents of the sent message from forwarding and saving
+     *       'reply_to_message_id'          => '',  // int        - (Optional). If the message is a reply, ID of the original message
+     *       'allow_sending_without_reply   => '',  // bool       - (Optional). Pass True, if the message should be sent even if the specified replied-to message is not found
+     *       'reply_markup'                 => '',  // string     - (Optional). Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#sendcontact
      *
-     * @param array    $params               [
-     *
-     * @var int|string $chat_id              Required. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
-     * @var string     $phone_number         Required. Contact's phone number
-     * @var string     $first_name           Required. Contact's first name
-     * @var string     $last_name            Required. Contact's last name
-     * @var string     $vcard                Optional. Additional data about the contact in the form of a vCard, 0-2048 bytes
-     * @var bool       $disable_notification Optional. Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.
-     * @var int        $reply_to_message_id  Optional. If the message is a reply, ID of the original message
-     * @var string     $reply_markup         Optional. Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
      *
@@ -529,27 +465,30 @@ trait Message
      *
      * <code>
      * $params = [
-     *   'chat_id'              => '',
-     *   'question'             => '',
-     *   'options'              => '',
-     *   'disable_notification' => '',
-     *   'reply_to_message_id'  => '',
-     *   'reply_markup'         => '',
-     * ];
+     *       'chat_id'                       => '',  // int|string - Required. Unique identifier for the target chat or username of the target channel (in the format "@channelusername"). A native poll can't be sent to a private chat.
+     *       'question'                      => '',  // string     - Required. Poll question, 1-255 characters
+     *       'options'                       => '',  // array      - Required. List of answer options, 2-10 strings 1-100 characters each
+     *       'is_anonymous'                  => '',  // bool       - (Optional). True, if the poll needs to be anonymous, defaults to True
+     *       'type'                          => '',  // string     - (Optional). Poll type, “quiz” or “regular”, defaults to “regular”
+     *       'allows_multiple_answers'       => '',  // bool       - (Optional). True, if the poll allows multiple answers, ignored for polls in quiz mode, defaults to False
+     *       'correct_option_id'             => '',  // int        - (Optional). 0-based identifier of the correct answer option, required for polls in quiz mode
+     *       'explanation'                   => '',  // string     - (Optional). Text that is shown when a user chooses an incorrect answer or taps on the lamp icon in a quiz-style poll, 0-200 characters with at most 2 line feeds after entities parsing
+     *       'explanation_parse_mode'        => '',  // string     - (Optional). Mode for parsing entities in the explanation. See formatting options for more details.
+     *       'explanation_entities'          => '',  // array      - (Optional). List of special entities that appear in the caption, which can be specified instead of parse_mode
+     *       'open_period'                   => '',  // int        - (Optional). Amount of time in seconds the poll will be active after creation, 5-600. Can't be used together with close_date.
+     *       'close_date'                    => '',  // int        - (Optional). Point in time (Unix timestamp) when the poll will be automatically closed. Must be at least 5 and no more than 600 seconds in the future. Can't be used together with open_period.
+     *       'is_closed'                     => '',  // bool       - (Optional). Pass True, if the poll needs to be immediately closed. This can be useful for poll preview.
+     *       'disable_notification'          => '',  // bool       - (Optional). Sends the message silently. Users will receive a notification with no sound.
+     *       'protect_content'               => '',  // bool       - (Optional). Protects the contents of the sent message from forwarding and saving
+     *       'reply_to_message_id'           => '',  // int        - (Optional). If the message is a reply, ID of the original message
+     *       'allow_sending_without_reply'   => '',  // bool       - (Optional). Pass True, if the message should be sent even if the specified replied-to message is not found
+     *       'reply_markup'                  => '',  // string     - (Optional). Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#sendpoll
      *
-     * @param array    $params               [
-     *
-     * @var int|string $chat_id              Required. Unique identifier for the target chat or username of the target channel (in the format @channelusername). A native poll can't be sent to a private chat.
-     * @var string     $question             Required. Poll question, 1-255 characters
-     * @var array      $options              Required. List of answer options, 2-10 strings 1-100 characters each
-     * @var bool       $disable_notification Optional. Sends the message silently. Users will receive a notification with no sound.
-     * @var int        $reply_to_message_id  Optional. If the message is a reply, ID of the original message
-     * @var string     $reply_markup         Optional. Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
      *
@@ -557,7 +496,9 @@ trait Message
      */
     public function sendPoll(array $params): MessageObject
     {
-        $params['options'] = json_encode($params['options']);
+        $params['options'] = is_string($params['options'])
+            ? $params['options']
+            : json_encode($params['options']);
         $response = $this->post('sendPoll', $params);
 
         return new MessageObject($response->getDecodedBody());
@@ -570,23 +511,19 @@ trait Message
      *
      * <code>
      * $params = [
-     *   'chat_id'              => '',
-     *   'disable_notification' => '',
-     *   'reply_to_message_id'  => '',
-     *   'reply_markup'         => '',
-     * ];
+     *       'chat_id'                       => '',  // int|string - Required. Unique identifier for the target chat or username of the target channel (in the format "@channelusername"). A native poll can't be sent to a private chat.
+     *       'emoji'                         => '',  // string     - (Optional). Emoji on which the dice throw animation is based. Currently, must be one of “🎲”, “🎯”, “🏀”, “⚽”, “🎳”, or “🎰”. Dice can have values 1-6 for “🎲”, “🎯” and “🎳”, values 1-5 for “🏀” and “⚽”, and values 1-64 for “🎰”. Defaults to “🎲”
+     *       'disable_notification'          => '',  // bool       - (Optional). Sends the message silently. Users will receive a notification with no sound.
+     *       'protect_content'               => '',  // bool       - (Optional). Protects the contents of the sent message from forwarding and saving
+     *       'reply_to_message_id'           => '',  // int        - (Optional). If the message is a reply, ID of the original message
+     *       'allow_sending_without_reply    => '',  // bool       - (Optional). Pass True, if the message should be sent even if the specified replied-to message is not found
+     *       'reply_markup'                  => '',  // string     - (Optional). Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#senddice
      *
-     * @param array    $params               [
-     *
-     * @var int|string $chat_id              Required. Unique identifier for the target chat or username of the target channel (in the format @channelusername). A native poll can't be sent to a private chat.
-     * @var bool       $disable_notification Optional. Sends the message silently. Users will receive a notification with no sound.
-     * @var int        $reply_to_message_id  Optional. If the message is a reply, ID of the original message
-     * @var string     $reply_markup         Optional. Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
      *
@@ -604,19 +541,14 @@ trait Message
      *
      * <code>
      * $params = [
-     *   'chat_id' => '',
-     *   'action'  => '',
-     * ];
+     *       'chat_id'  => '',  // int|string - Required. Unique identifier for the target chat or username of the target channel (in the format "@channelusername")
+     *       'action'   => '',  // string     - Required. Type of action to broadcast. Choose one, depending on what the user is about to receive: typing for text messages, upload_photo for photos, record_video or upload_video for videos, record_voice or upload_voice for voice notes, upload_document for general files, choose_sticker for stickers, find_location for location data, record_video_note or upload_video_note for video notes.
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#sendchataction
      *
-     * @param array    $params  [
-     *
-     * @var int|string $chat_id Required. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
-     * @var string     $action  Required. Type of action to broadcast. Choose one, depending on what the user is about to receive: typing for text messages, upload_photo for photos, record_video or upload_video for videos, record_audio or upload_audio for audio files, upload_document for general files, find_location for location data.
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
      *
@@ -644,52 +576,5 @@ trait Message
         }
 
         throw new TelegramSDKException('Invalid Action! Accepted value: '.implode(', ', $validActions));
-    }
-       /**
-     * copy a message .
-     *
-     * <code>
-     * $params = [
-     *   'chat_id'                      => '',
-     *   'from_chat_id'                 => '',
-     *   'message_id'                   => '',
-     *   'caption'                      => '',
-     *   'parse_mode'                   => '',
-     *   'caption_entities'             => '',
-     *   'disable_notification'         => '',
-     *   'protect_content'              => '',
-     *   'reply_to_message_id'          => '',
-     *   'allow_sending_without_reply'  => '',
-     *   'reply_markup'                 => '',
-     * ];
-     * </code>
-     *
-     * @link https://core.telegram.org/bots/api#copyMessage
-     *
-     * @param array    $params                   [
-     *
-     * @var int|string $chat_id                     Required. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
-     * @var int|string $from_chat_id                Required. Unique identifier for the chat where the original message was sent (or channel username in the format @channelusername)
-     * @var int        $message_id                  Required. Message identifier in the chat specified in from_chat_id
-     * @var string     $caption                     Optional. Photo caption (may also be used when resending photos by file_id), 0-200 characters
-     * @var string     $parse_mode                  Optional. Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in the media caption.
-     * @var bool       $caption_entities            Optional. A JSON-serialized list of special entities that appear in the new caption, which can be specified instead of parse_mode
-     * @var bool       $disable_notification        Optional. Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.
-     * @var bool       $protect_content             Optional. Protects the contents of the sent message from forwarding and saving
-     * @var int        $reply_to_message_id         Optional. If the message is a reply, ID of the original message
-     * @var bool       $allow_sending_without_reply Optional. Pass True, if the message should be sent even if the specified replied-to message is not found
-     * @var string     $reply_markup                Optional. Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
-     *
-     * ]
-     *
-     * @throws \Telegram\Bot\Exceptions\TelegramSDKException
-     *
-     * @return MessageObject
-     */
-    public function copyMessage(array $params): MessageObject
-    {
-        $response = $this->post('copyMessage', $params);
-
-        return new MessageObject($response->getDecodedBody());
     }
 }

--- a/src/Methods/Passport.php
+++ b/src/Methods/Passport.php
@@ -9,9 +9,9 @@ trait Passport
      *
      * <code>
      * $params = [
-     *   'user_id'                 => '',
-     *   'errors'                  => '',
-     * ];
+     *      'user_id'     => '',  // int                    - Required. User identifier
+     *      'errors'      => '',  // PassportElementError[] - Required. A JSON-serialized array describing the errors
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#setpassportdataerrors

--- a/src/Methods/Payments.php
+++ b/src/Methods/Payments.php
@@ -4,13 +4,12 @@ namespace Telegram\Bot\Methods;
 
 use Telegram\Bot\Exceptions\TelegramSDKException;
 use Telegram\Bot\Objects\Message;
-use Telegram\Bot\Objects\Payments\LabeledPrice;
-use Telegram\Bot\Objects\Payments\ShippingOption;
 use Telegram\Bot\Traits\Http;
 use Illuminate\Support\Arr;
 
 /**
  * Trait Payments.
+ *
  * @mixin Http
  */
 trait Payments
@@ -20,58 +19,39 @@ trait Payments
      *
      * <code>
      * $params = [
-     *   'chat_id'                 => '',
-     *   'title'                   => '',
-     *   'description'             => '',
-     *   'payload'                 => '',
-     *   'provider_token'          => '',
-     *   'start_parameter'         => '',
-     *   'currency'                => '',
-     *   'prices'                  => '',
-     *   'photo_url'               => '',
-     *   'photo_size'              => '',
-     *   'photo_width'             => '',
-     *   'photo_height'            => '',
-     *   'need_name'               => '',
-     *   'need_phone_number'       => '',
-     *   'need_email'              => '',
-     *   'need_shipping_address'   => '',
-     *   'is_flexible'             => '',
-     *   'disable_notification'    => '',
-     *   'reply_to_message_id'     => '',
-     *   'reply_markup'            => '',
-     * ];
+     *      'chat_id'                        => '',  // int            - Required. Unique identifier for the target chat or username of the target channel (in the format "@channelusername")
+     *      'title'                          => '',  // string         - Required. Product name, 1-32 characters
+     *      'description'                    => '',  // string         - Required. Product description, 1-255 characters
+     *      'payload'                        => '',  // string         - Required. Bot-defined invoice payload, 1-128 bytes. This will not be displayed to the user, use for your internal processes.
+     *      'provider_token'                 => '',  // string         - Required. Payments provider token, obtained via Botfather
+     *      'currency'                       => '',  // string         - Required. Three-letter ISO 4217 currency code
+     *      'prices'                         => '',  // LabeledPrice[] - Required. Price breakdown, a list of components (e.g. product price, tax, discount, delivery cost, delivery tax, bonus, etc.)
+     *      'max_tip_amount'                 => '',  // int            - (Optional). The maximum accepted amount for tips in the smallest units of the currency (integer, not float/double). For example, for a maximum tip of US$ 1.45 pass max_tip_amount = 145. See the exp parameter in currencies.json, it shows the number of digits past the decimal point for each currency (2 for the majority of currencies). Defaults to 0
+     *      'suggested_tip_amounts'          => '',  // int[]          - (Optional). A JSON-serialized array of suggested amounts of tips in the smallest units of the currency (integer, not float/double). At most 4 suggested tip amounts can be specified. The suggested tip amounts must be positive, passed in a strictly increased order and must not exceed max_tip_amount.
+     *      'start_parameter'                => '',  // string         - (Optional). Unique deep-linking parameter. If left empty, forwarded copies of the sent message will have a Pay button, allowing multiple users to pay directly from the forwarded message, using the same invoice. If non-empty, forwarded copies of the sent message will have a URL button with a deep link to the bot (instead of a Pay button), with the value used as the start parameter
+     *      'provider_data'                  => '',  // string         - (Optional). JSON-encoded data about the invoice, which will be shared with the payment provider. A detailed description of required fields should be provided by the payment provider.
+     *      'photo_url'                      => '',  // string         - (Optional). URL of the product photo for the invoice. Can be a photo of the goods or a marketing image for a service. People like it better when they see what they are paying for.
+     *      'photo_size'                     => '',  // int            - (Optional). Photo size
+     *      'photo_width'                    => '',  // int            - (Optional). Photo width
+     *      'photo_height'                   => '',  // int            - (Optional). Photo height
+     *      'need_name'                      => '',  // bool           - (Optional). Pass True, if you require the user's full name to complete the order
+     *      'need_phone_number'              => '',  // bool           - (Optional). Pass True, if you require the user's phone number to complete the order
+     *      'need_email'                     => '',  // bool           - (Optional). Pass True, if you require the user's email to complete the order
+     *      'need_shipping_address'          => '',  // bool           - (Optional). Pass True, if you require the user's shipping address to complete the order
+     *      'send_phone_number_to_provider'  => '',  // bool           - (Optional). Pass True, if user's phone number should be sent to provider
+     *      'send_email_to_provider'         => '',  // bool           - (Optional). Pass True, if user's email address should be sent to provider
+     *      'is_flexible'                    => '',  // bool           - (Optional). Pass True, if the final price depends on the shipping method
+     *      'disable_notification'           => '',  // bool           - (Optional). Sends the message silently. Users will receive a notification with no sound.
+     *      'protect_content'                => '',  // bool           - (Optional). Protects the contents of the sent message from forwarding and saving
+     *      'reply_to_message_id'            => '',  // int            - (Optional). If the message is a reply, ID of the original message
+     *      'allow_sending_without_reply     => '',  // boo            - (Optional). Pass True, if the message should be sent even if the specified replied-to message is not found
+     *      'reply_markup'                   => '',  // string         - (Optional). A JSON-serialized object for an inline keyboard. If empty, one 'Pay total price' button will be shown. If not empty, the first button must be a Pay button.
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#sendinvoice
      *
-     * @param array        $params              [
-     *
-     * @var int            $chat_id                         Required. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
-     * @var string         $title                           Required. Product name, 1-32 characters
-     * @var string         $description                     Required. Product description, 1-255 characters
-     * @var string         $payload                         Required. Bot-defined invoice payload, 1-128 bytes. This will not be displayed to the user, use for your internal processes.
-     * @var string         $providerToken                   Required. Payments provider token, obtained via Botfather
-     * @var string         $startParameter                  Required. Unique deep-linking parameter that can be used to generate this invoice when used as a start parameter
-     * @var string         $currency                        Required. Three-letter ISO 4217 currency code
-     * @var LabeledPrice[] $prices                          Required. Price breakdown, a list of components (e.g. product price, tax, discount, delivery cost, delivery tax, bonus, etc.)
-     * @var string         $provider_data                   Optional. JSON-encoded data about the invoice, which will be shared with the payment provider. A detailed description of required fields should be provided by the payment provider.
-     * @var string         $photoUrl                        Optional. URL of the product photo for the invoice. Can be a photo of the goods or a marketing image for a service. People like it better when they see what they are paying for.
-     * @var int            $photoSize                       Optional. Photo size
-     * @var int            $photoWidth                      Optional. Photo width
-     * @var int            $photoHeight                     Optional. Photo height
-     * @var bool           $needName                        Optional. Pass True, if you require the user's full name to complete the order
-     * @var bool           $needPhoneNumber                 Optional. Pass True, if you require the user's phone number to complete the order
-     * @var bool           $needEmail                       Optional. Pass True, if you require the user's email to complete the order
-     * @var bool           $needShippingAddress             Optional. Pass True, if you require the user's shipping address to complete the order
-     * @var bool           $send_phone_number_to_provider   Optional. Pass True, if user's phone number should be sent to provider
-     * @var bool           $send_email_to_provider          Optional. Pass True, if user's email address should be sent to provider
-     * @var bool           $isFlexible                      Optional. Pass True, if the final price depends on the shipping method
-     * @var bool           $disableNotification             Optional. Sends the message silently. Users will receive a notification with no sound.
-     * @var int            $reply_to_message_id             Optional. If the message is a reply, ID of the original message
-     * @var string         $reply_markup                    Optional. A JSON-serialized object for an inline keyboard. If empty, one 'Pay total price' button will be shown. If not empty, the first button must be a Pay button.
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
      *
@@ -90,23 +70,16 @@ trait Payments
      *
      * <code>
      * $params = [
-     *   'shipping_query_id'  => '',
-     *   'ok'                 => '',
-     *   'shipping_options'   => '',
-     *   'error_message'      => '',
-     * ];
+     *      'shippingQueryId'  => '',  // string           - Required. Unique identifier for the query to be answered
+     *      'ok'               => '',  // bool             - Required. Specify True if delivery to the specified address is possible and False if there are any problems (for example, if delivery to the specified address is not possible)
+     *      'shippingOptions'  => '',  // ShippingOption[] - (Optional|Required). Required if ok is True. A JSON-serialized array of available shipping options.
+     *      'errorMessage'     => '',  // string           - (Optional|Required). Required if ok is False. Error message in human readable form that explains why it is impossible to complete the order (e.g. "Sorry, delivery to your desired address is unavailable'). Telegram will display this message to the user.
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#answershippingquery
      *
-     * @param array          $params          [
-     *
-     * @var string           $shippingQueryId Required. Unique identifier for the query to be answered
-     * @var bool             $ok              Required. Specify True if delivery to the specified address is possible and False if there are any problems (for example, if delivery to the specified address is not possible)
-     * @var ShippingOption[] $shippingOptions (Optional|Required). Required if ok is True. A JSON-serialized array of available shipping options.
-     * @var string           $errorMessage    (Optional|Required). Required if ok is False. Error message in human readable form that explains why it is impossible to complete the order (e.g. "Sorry, delivery to your desired address is unavailable'). Telegram will display this message to the user.
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
      *
@@ -114,9 +87,7 @@ trait Payments
      */
     public function answerShippingQuery(array $params): bool
     {
-        $response = $this->post('answerShippingQuery', $params);
-
-        return $response->getResult();
+        return $this->post('answerShippingQuery', $params)->getResult();
     }
 
     /**
@@ -124,21 +95,15 @@ trait Payments
      *
      * <code>
      * $params = [
-     *   'pre_checkout_query_id'  => '',
-     *   'ok'                     => '',
-     *   'error_message'          => '',
-     * ];
+     *      'preCheckoutQueryId'  => '',  // string - Required. Unique identifier for the query to be answered
+     *      'ok'                  => '',  // bool   - Required. Specify True if everything is alright (goods are available, etc.) and the bot is ready to proceed with the order. Use False if there are any problems.
+     *      'errorMessage'        => '',  // string - (Optional|Required). Required if ok is False. Error message in human readable form that explains the reason for failure to proceed with the checkout (e.g. "Sorry, somebody just bought the last of our amazing black T-shirts while you were busy filling out your payment details. Please choose a different color or garment!"). Telegram will display this message to the user.
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#answerprecheckoutquery
      *
-     * @param array          $params          [
-     *
-     * @var string           $preCheckoutQueryId Required. Unique identifier for the query to be answered
-     * @var bool             $ok              Required. Specify True if everything is alright (goods are available, etc.) and the bot is ready to proceed with the order. Use False if there are any problems.
-     * @var string           $errorMessage    (Optional|Required). Required if ok is False. Error message in human readable form that explains the reason for failure to proceed with the checkout (e.g. "Sorry, somebody just bought the last of our amazing black T-shirts while you were busy filling out your payment details. Please choose a different color or garment!"). Telegram will display this message to the user.
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
      *
@@ -146,8 +111,6 @@ trait Payments
      */
     public function answerPreCheckoutQuery(array $params): bool
     {
-        $response = $this->post('answerPreCheckoutQuery', $params);
-
-        return $response->getResult();
+        return $this->post('answerPreCheckoutQuery', $params)->getResult();
     }
 }

--- a/src/Methods/Query.php
+++ b/src/Methods/Query.php
@@ -7,12 +7,14 @@ use Telegram\Bot\Traits\Http;
 
 /**
  * Class Query.
+ *
  * @mixin Http
  */
 trait Query
 {
-    //TODO Check these methods. They should possibly return the result of the query,
-    //not just a hard coded bool value.
+    // TODO
+    // Check these methods. They should possibly return the result of the query,
+    // not just a hard coded bool value.
 
     /**
      * Send answers to callback queries sent from inline keyboards.
@@ -21,25 +23,17 @@ trait Query
      *
      * <code>
      * $params = [
-     *   'callback_query_id'  => '',
-     *   'text'               => '',
-     *   'show_alert'         => '',
-     *   'url'                => '',
-     *   'cache_time'         => '',
-     * ];
+     *       'callback_query_id'  => '',  // string - Required. Unique identifier for the query to be answered
+     *       'text'               => '',  // string - (Optional). Text of the notification. If not specified, nothing will be shown to the user, 0-200 characters
+     *       'show_alert'         => '',  // bool   - (Optional). If true, an alert will be shown by the client instead of a notification at the top of the chat screen. Defaults to false.
+     *       'url'                => '',  // string - (Optional). URL that will be opened by the user's client. If you have created a Game and accepted the conditions via "@Botfather", specify the URL that opens your game – note that this will only work if the query comes from a callback_game button. Otherwise, you may use links like telegram.me/your_bot?start=XXXX that open your bot with a parameter.
+     *       'cache_time'         => '',  // int    - (Optional). The maximum amount of time in seconds that the result of the callback query may be cached client-side. Telegram apps will support caching starting in version 3.14. Defaults to 0.
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#answerCallbackQuery
      *
-     * @param array $params [
-     *
-     * @var string $callback_query_id Required. Unique identifier for the query to be answered
-     * @var string $text              Optional. Text of the notification. If not specified, nothing will be shown to the user, 0-200 characters
-     * @var bool   $show_alert        Optional. If true, an alert will be shown by the client instead of a notification at the top of the chat screen. Defaults to false.
-     * @var string $url               Optional. URL that will be opened by the user's client. If you have created a Game and accepted the conditions via @Botfather, specify the URL that opens your game – note that this will only work if the query comes from a callback_game button. Otherwise, you may use links like telegram.me/your_bot?start=XXXX that open your bot with a parameter.
-     * @var int    $cache_time        Optional. The maximum amount of time in seconds that the result of the callback query may be cached client-side. Telegram apps will support caching starting in version 3.14. Defaults to 0.
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
      *
@@ -59,29 +53,19 @@ trait Query
      *
      * <code>
      * $params = [
-     *   'inline_query_id'      => '',
-     *   'results'              => [],
-     *   'cache_time'           => 0,
-     *   'is_personal'          => false,
-     *   'next_offset'          => '',
-     *   'switch_pm_text'       => '',
-     *   'switch_pm_parameter'  => '',
-     * ];
+     *       'inline_query_id'      => '',  // string - Required. Unique identifier for the answered query
+     *       'results'              => '',  // array  - Required. A JSON-serialized array of results for the inline query
+     *       'cache_time'           => '',  // int    - (Optional). The maximum amount of time in seconds that the result of the inline query may be cached on the server. Defaults to 300.
+     *       'is_personal'          => '',  // bool   - (Optional). Pass True, if results may be cached on the server side only for the user that sent the query. By default, results may be returned to any user who sends the same query
+     *       'next_offset'          => '',  // string - (Optional). Pass the offset that a client should send in the next query with the same text to receive more results. Pass an empty string if there are no more results or if you don‘t support pagination. Offset length can’t exceed 64 bytes.
+     *       'switch_pm_text'       => '',  // string - (Optional). If passed, clients will display a button with specified text that switches the user to a private chat with the bot and sends the bot a start message with the parameter switch_pm_parameter
+     *       'switch_pm_parameter'  => '',  // string - (Optional). Deep-linking parameter for the /start message sent to the bot when user presses the switch button. 1-64 characters, only A-Z, a-z, 0-9, _ and - are allowed.
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#answerCallbackQuery
      *
-     * @param array $params [
-     *
-     * @var string $inline_query_id     Required. Unique identifier for the answered query
-     * @var array  $results             Required. A JSON-serialized array of results for the inline query
-     * @var int    $cache_time          Optional. The maximum amount of time in seconds that the result of the inline query may be cached on the server. Defaults to 300.
-     * @var bool   $is_personal         Optional. Pass True, if results may be cached on the server side only for the user that sent the query. By default, results may be returned to any user who sends the same query
-     * @var string $next_offset         Optional. Pass the offset that a client should send in the next query with the same text to receive more results. Pass an empty string if there are no more results or if you don‘t support pagination. Offset length can’t exceed 64 bytes.
-     * @var string $switch_pm_text      Optional. If passed, clients will display a button with specified text that switches the user to a private chat with the bot and sends the bot a start message with the parameter switch_pm_parameter
-     * @var string $switch_pm_parameter Optional. Deep-linking parameter for the /start message sent to the bot when user presses the switch button. 1-64 characters, only A-Z, a-z, 0-9, _ and - are allowed.
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
      *

--- a/src/Methods/Stickers.php
+++ b/src/Methods/Stickers.php
@@ -3,9 +3,7 @@
 namespace Telegram\Bot\Methods;
 
 use Telegram\Bot\Exceptions\TelegramSDKException;
-use Telegram\Bot\FileUpload\InputFile;
 use Telegram\Bot\Objects\File;
-use Telegram\Bot\Objects\MaskPosition;
 use Telegram\Bot\Objects\Message as MessageObject;
 use Telegram\Bot\Objects\StickerSet;
 use Telegram\Bot\Traits\Http;
@@ -21,25 +19,19 @@ trait Stickers
      *
      * <code>
      * $params = [
-     *   'chat_id'              => '',
-     *   'sticker'              => InputFile::create($resourceOrFile, $filename),
-     *   'disable_notification' => '',
-     *   'reply_to_message_id'  => '',
-     *   'reply_markup'         => '',
-     * ];
+     *       'chat_id'                      => '',                      // int|string       - Required. Unique identifier for the target chat or username of the target channel (in the format "@channelusername")
+     *       'sticker'                      => InputFile::file($file),  // InputFile|string - Required. Sticker to send. Pass a file_id as String to send a file that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get a .webp file from the Internet, or upload a new one using multipart/form-data.
+     *       'disable_notification'         => '',                      // bool             - (Optional). Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.
+     *       'protect_content'              => '',                      // bool             - (Optional). Protects the contents of the sent message from forwarding and saving
+     *       'reply_to_message_id'          => '',                      // int              - (Optional). If the message is a reply, ID of the original message
+     *       'allow_sending_without_reply   => '',                      // bool             - (Optional). Pass True, if the message should be sent even if the specified replied-to message is not found
+     *       'reply_markup'                 => '',                      // string           - (Optional). Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#sendsticker
      *
-     * @param array          $params               [
-     *
-     * @var int|string       $chat_id              Required. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
-     * @var InputFile|string $sticker              Required. Sticker to send. Pass a file_id as String to send a file that exists on the Telegram servers (recommended), pass an HTTP URL as a String for Telegram to get a .webp file from the Internet, or upload a new one using multipart/form-data.
-     * @var bool             $disable_notification Optional. Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.
-     * @var int              $reply_to_message_id  Optional. If the message is a reply, ID of the original message
-     * @var string           $reply_markup         Optional. Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
      *
@@ -57,17 +49,13 @@ trait Stickers
      *
      * <code>
      * $params = [
-     *   'name'              => '',
-     * ];
+     *       'name'  => '',  // string - Required. Name of the sticker set
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#getstickerset
      *
-     * @param array $params [
-     *
-     * @var string  $name   Required. Name of the sticker set
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
      *
@@ -86,19 +74,14 @@ trait Stickers
      *
      * <code>
      * $params = [
-     *   'user_id'              => '',
-     *   'png_sticker'          => InputFile::create($resourceOrFile, $filename),
-     * ];
+     *       'user_id'      => '',                      // int       - Required. Unique identifier for the target chat or username of the target channel (in the format "@channelusername")
+     *       'png_sticker'  => InputFile::file($file),  // InputFile - Required. Png image with the sticker, must be up to 512 kilobytes in size, dimensions must not exceed 512px, and either width or height must be exactly 512px.
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#uploadstickerfile
      *
-     * @param array   $params      [
-     *
-     * @var int       $user_id     Required. Unique identifier for the target chat or username of the target channel (in the format @channelusername)
-     * @var InputFile $png_sticker Required. Png image with the sticker, must be up to 512 kilobytes in size, dimensions must not exceed 512px, and either width or height must be exactly 512px.
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
      *
@@ -116,31 +99,20 @@ trait Stickers
      *
      * <code>
      * $params = [
-     *   'user_id'           => '',
-     *   'name'              => '',
-     *   'title'             => '',
-     *   'png_sticker'       => '',
-     *   'tgs_sticker'       => '',
-     *   'emojis'            => '',
-     *   'contains_masks'    => '',
-     *   'mask_position'     => '',
-     * ];
+     *       'user_id'         => '',                           // int              - Required. User identifier of created sticker set owner
+     *       'name'            => '',                           // string           - Required. Short name of sticker set, to be used in t.me/addstickers/ URLs (e.g., animals). Can contain only english letters, digits and underscores. Must begin with a letter, can't contain consecutive underscores and must end in “_by_<bot username>”. <bot_username> is case insensitive. 1-64 characters.
+     *       'title'           => '',                           // string           - Required. Sticker set title, 1-64 characters
+     *       'png_sticker'     => InputFile::file($file),       // InputFile|string - (Optional). Png image with the sticker, must be up to 512 kilobytes in size, dimensions must not exceed 512px, and either width or height must be exactly 512px. Pass a file_id as a String to send a file that already exists on the Telegram servers, pass an HTTP URL as a String for Telegram to get a file from the Internet, or upload a new one using multipart/form-data.
+     *       'tgs_sticker'     => InputFile::file($file),       // InputFile        - (Optional). TGS animation with the sticker, uploaded using multipart/form-data. See https://core.telegram.org/animated_stickers#technical-requirements for technical requirements
+     *       'emojis'          => '',                           // string           - Required. One or more emoji corresponding to the sticker
+     *       'contains_masks'  => '',                           // bool             - (Optional). Pass True, if a set of mask stickers should be created
+     *       'mask_position'   => MaskPosition::make($fields),  // MaskPosition     - (Optional). A JSON-serialized object for position where the mask should be placed on faces
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#createnewstickerset
      *
-     * @param array          $params         [
-     *
-     * @var int              $user_id        Required. User identifier of created sticker set owner
-     * @var string           $name           Required. Short name of sticker set, to be used in t.me/addstickers/ URLs (e.g., animals). Can contain only english letters, digits and underscores. Must begin with a letter, can't contain consecutive underscores and must end in “_by_<bot username>”. <bot_username> is case insensitive. 1-64 characters.
-     * @var string           $title          Required. Sticker set title, 1-64 characters
-     * @var InputFile|string $png_sticker    (Optional). Png image with the sticker, must be up to 512 kilobytes in size, dimensions must not exceed 512px, and either width or height must be exactly 512px. Pass a file_id as a String to send a file that already exists on the Telegram servers, pass an HTTP URL as a String for Telegram to get a file from the Internet, or upload a new one using multipart/form-data.
-     * @var InputFile        $tgs_sticker    (Optional). TGS animation with the sticker, uploaded using multipart/form-data. See https://core.telegram.org/animated_stickers#technical-requirements for technical requirements
-     * @var string           $emojis         Required. One or more emoji corresponding to the sticker
-     * @var bool             $contains_masks (Optional). Pass True, if a set of mask stickers should be created
-     * @var MaskPosition     $mask_position  (Optional). A JSON-serialized object for position where the mask should be placed on faces
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
      *
@@ -148,9 +120,7 @@ trait Stickers
      */
     public function createNewStickerSet(array $params): bool
     {
-        $response = $this->uploadFile('createNewStickerSet', $params, 'png_sticker');
-
-        return $response->getResult();
+        return $this->uploadFile('createNewStickerSet', $params, 'png_sticker')->getResult();
     }
 
     /**
@@ -158,27 +128,18 @@ trait Stickers
      *
      * <code>
      * $params = [
-     *   'user_id'           => '',
-     *   'name'              => '',
-     *   'png_sticker'       => '',
-     *   'tgs_sticker'       => '',
-     *   'emojis'            => '',
-     *   'mask_position'     => '',
-     * ];
+     *       'user_id'        => '',                           // int              - Required. User identifier of sticker set owner
+     *       'name'           => '',                           // string           - Required. Sticker set name
+     *       'png_sticker'    => InputFile::file($file),       // InputFile|string - Required. Png image with the sticker, must be up to 512 kilobytes in size, dimensions must not exceed 512px, and either width or height must be exactly 512px. Pass a file_id as a String to send a file that already exists on the Telegram servers, pass an HTTP URL as a String for Telegram to get a file from the Internet, or upload a new one using multipart/form-data.
+     *       'tgs_sticker'    => InputFile::file($file),       // InputFile        - (Optional). TGS animation with the sticker, uploaded using multipart/form-data. See https://core.telegram.org/animated_stickers#technical-requirements for technical requirements
+     *       'emojis'         => '',                           // string           - Required. One or more emoji corresponding to the sticker
+     *       'mask_position'  => MaskPosition::make($fields),  // MaskPosition     - (Optional). A JSON-serialized object for position where the mask should be placed on faces
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#addstickertoset
      *
-     * @param array          $params        [
-     *
-     * @var int              $user_id       Required. User identifier of sticker set owner
-     * @var string           $name          Required. Sticker set name
-     * @var InputFile|string $png_sticker   Required. Png image with the sticker, must be up to 512 kilobytes in size, dimensions must not exceed 512px, and either width or height must be exactly 512px. Pass a file_id as a String to send a file that already exists on the Telegram servers, pass an HTTP URL as a String for Telegram to get a file from the Internet, or upload a new one using multipart/form-data.
-     * @var InputFile        $tgs_sticker   (Optional). TGS animation with the sticker, uploaded using multipart/form-data. See https://core.telegram.org/animated_stickers#technical-requirements for technical requirements
-     * @var string           $emojis        Required. One or more emoji corresponding to the sticker
-     * @var MaskPosition     $mask_position (Optional). A JSON-serialized object for position where the mask should be placed on faces
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
      *
@@ -186,9 +147,7 @@ trait Stickers
      */
     public function addStickerToSet(array $params): bool
     {
-        $response = $this->uploadFile('addStickerToSet', $params, 'png_sticker');
-
-        return $response->getResult();
+        return $this->uploadFile('addStickerToSet', $params, 'png_sticker')->getResult();
     }
 
     /**
@@ -196,19 +155,14 @@ trait Stickers
      *
      * <code>
      * $params = [
-     *   'sticker'              => '',
-     *   'position'             => '',
-     * ];
+     *       'sticker'   => '',  // string - Required. File identifier of the sticker
+     *       'position'  => '',  // string - Required. New sticker position in the set, zero-based.
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#setstickerpositioninset
      *
-     * @param array $params   [
-     *
-     * @var string  $sticker  Required. File identifier of the sticker
-     * @var string  $position Required. New sticker position in the set, zero-based.
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
      *
@@ -216,9 +170,7 @@ trait Stickers
      */
     public function setStickerPositionInSet(array $params): bool
     {
-        $response = $this->post('setStickerPositionInSet', $params);
-
-        return $response->getResult();
+        return $this->post('setStickerPositionInSet', $params)->getResult();
     }
 
     /**
@@ -226,17 +178,13 @@ trait Stickers
      *
      * <code>
      * $params = [
-     *   'sticker'              => '',
-     * ];
+     *       'sticker'  => '',  // string - Required. File identifier of the sticker
+     * ]
      * </code>
      *
      * @link https://core.telegram.org/bots/api#deletestickerfromset
      *
-     * @param array $params   [
-     *
-     * @var string  $sticker  Required. File identifier of the sticker
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
      *
@@ -244,9 +192,7 @@ trait Stickers
      */
     public function deleteStickerFromSet(array $params): bool
     {
-        $response = $this->post('deleteStickerFromSet', $params);
-
-        return $response->getResult();
+        return $this->post('deleteStickerFromSet', $params)->getResult();
     }
 
     /**
@@ -254,21 +200,15 @@ trait Stickers
      *
      * <code>
      * $params = [
-     *   'name'          => '',
-     *   'user_id'       => '',
-     *   'thumb'         => '',
-     * ];
-     * </code>
+     *       'name'     => '',                      // string           - Required. Sticker set name
+     *       'user_id'  => '',                      // int              - Required. User identifier of sticker set owner
+     *       'thumb'    => InputFile::file($file),  // InputFile|string - (Optional). A PNG image with the thumbnail, must be up to 128 kilobytes in size and have width and height exactly 100px, or a TGS animation with the thumbnail up to 32 kilobytes in size; see https://core.telegram.org/animated_stickers#technical-requirements for animated sticker technical requirements. Pass a file_id as a String to send a file that already exists on the Telegram servers, pass an HTTP URL as a String for Telegram to get a file from the Internet, or upload a new one using multipart/form-data. More info on Sending Files ». Animated sticker set thumbnail can't be uploaded via HTTP URL
+     * ]
      *
      * @link https://core.telegram.org/bots/api#setstickersetthumb
+     * </code>
      *
-     * @param array          $params        [
-     *
-     * @var string           $name          Required. Sticker set name
-     * @var int              $user_id       Required. User identifier of sticker set owner
-     * @var InputFile|string $thumb         (Optional). A PNG image with the thumbnail, must be up to 128 kilobytes in size and have width and height exactly 100px, or a TGS animation with the thumbnail up to 32 kilobytes in size; see https://core.telegram.org/animated_stickers#technical-requirements for animated sticker technical requirements. Pass a file_id as a String to send a file that already exists on the Telegram servers, pass an HTTP URL as a String for Telegram to get a file from the Internet, or upload a new one using multipart/form-data. More info on Sending Files ». Animated sticker set thumbnail can't be uploaded via HTTP URL
-     *
-     * ]
+     * @param array $params
      *
      * @throws TelegramSDKException
      *
@@ -276,9 +216,6 @@ trait Stickers
      */
     public function setStickerSetThumb(array $params): bool
     {
-        $response = $this->uploadFile('setStickerSetThumb', $params, 'thumb');
-
-        return $response->getResult();
+        return $this->uploadFile('setStickerSetThumb', $params, 'thumb')->getResult();
     }
-
 }

--- a/src/Objects/Animation.php
+++ b/src/Objects/Animation.php
@@ -5,6 +5,8 @@ namespace Telegram\Bot\Objects;
 /**
  * Class Animation.
  *
+ * @link https://core.telegram.org/bots/api#animation
+ *
  * @property string         $fileId           Unique file identifier.
  * @property string         $fileUniqueId     Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
  * @property int            $width            Video width as defined by sender.

--- a/src/Objects/Audio.php
+++ b/src/Objects/Audio.php
@@ -5,6 +5,7 @@ namespace Telegram\Bot\Objects;
 /**
  * Class Audio.
  *
+ * @link https://core.telegram.org/bots/api#audio
  *
  * @property string         $fileId           Unique identifier for this file.
  * @property string         $fileUniqueId     Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.

--- a/src/Objects/BaseObject.php
+++ b/src/Objects/BaseObject.php
@@ -157,6 +157,46 @@ abstract class BaseObject extends Collection
     }
 
     /**
+     * Detect type based on fields.
+     *
+     * @return string|null
+     */
+    public function objectType(): ?string
+    {
+        return null;
+    }
+
+    /**
+     * Determine if the object is of given type.
+     *
+     * @param string $type
+     *
+     * @return bool
+     */
+    public function isType($type)
+    {
+        if ($this->offsetExists($type)) {
+            return true;
+        }
+
+        return $this->objectType() === $type;
+    }
+
+    /**
+     * Determine the type by given types.
+     *
+     * @param array $types
+     *
+     * @return string|null
+     */
+    protected function findType(array $types): ?string
+    {
+        $this->keys()
+            ->intersect($types)
+            ->pop();
+    }
+
+    /**
      * Magic method to get properties dynamically.
      *
      * @param $name

--- a/src/Objects/CallbackQuery.php
+++ b/src/Objects/CallbackQuery.php
@@ -5,6 +5,8 @@ namespace Telegram\Bot\Objects;
 /**
  * Class CallbackQuery.
  *
+ * @link https://core.telegram.org/bots/api#callbackquery
+ *
  * @property int          $id                        Unique message identifier.
  * @property User         $from                      Sender.
  * @property Message|null $message                   (Optional). Message with the callback button that originated the query. Note that message content and message date will not be available if the message is too old.
@@ -21,8 +23,14 @@ class CallbackQuery extends BaseObject
     public function relations()
     {
         return [
-            'from' => User::class,
+            'from'    => User::class,
             'message' => Message::class,
         ];
+    }
+
+    public function objectType(): ?string
+    {
+        //TODO - Check if message and inline_message_id are exclusive to each other
+        return $this->findType(['data', 'game_short_name']);
     }
 }

--- a/src/Objects/Chat.php
+++ b/src/Objects/Chat.php
@@ -7,6 +7,7 @@ use Telegram\Bot\Objects\InputMedia\InputMedia;
 /**
  * Class Chat.
  *
+ * @link https://core.telegram.org/bots/api#chat
  *
  * @property int                  $id                           Unique identifier for this chat, not exceeding 1e13 by absolute value.
  * @property string               $type                         Type of chat, can be either 'private', 'group', 'supergroup' or 'channel'.
@@ -15,13 +16,18 @@ use Telegram\Bot\Objects\InputMedia\InputMedia;
  * @property string|null          $firstName                    (Optional). First name of the other party in a private chat
  * @property string|null          $lastName                     (Optional). Last name of the other party in a private chat
  * @property InputMedia|null      $photo                        (Optional). Chat photo. Returned only in getChat.
+ * @property string|null          $bio                          (Optional). Bio of the other party in a private chat. Returned only in getChat
+ * @property bool|null            $hasPrivateForwards           (Optional). True, if privacy settings of the other party in the private chat allows to use tg://user?id=<user_id> links only in chats with the user. Returned only in getChat.
  * @property string|null          $description                  (Optional). Description, for groups, supergroups and channel chats. Returned only in getChat.
  * @property string|null          $inviteLink                   (Optional). Chat invite link, for groups, supergroups and channel chats. Each administrator in a chat generates their own invite links, so the bot must first generate the link using exportChatInviteLink. Returned only in getChat.
  * @property Message|null         $pinnedMessage                (Optional). Pinned message, for groups, supergroups and channels. Returned only in getChat.
  * @property ChatPermissions|null $permissions                  (Optional). Pinned message, for groups, supergroups and channels. Returned only in getChat.
  * @property int|null             $slowModeDelay                (Optional). For supergroups, the minimum allowed delay between consecutive messages sent by each unpriviledged user. Returned only in getChat.
+ * @property bool|null            $hasProtectedContent          (Optional). True, if messages from the chat can't be forwarded to other chats. Returned only in getChat.
  * @property string|null          $stickerSetName               (Optional). For supergroups, name of group sticker set. Returned only in getChat.
  * @property bool|null            $canSetStickerSet             (Optional). True, if the bot can change the group sticker set. Returned only in getChat.
+ * @property int|null             $linkedChatId                 (Optional). Unique identifier for the linked chat, i.e. the discussion group identifier for a channel and vice versa; for supergroups and channel chats. This identifier may be greater than 32 bits and some programming languages may have difficulty/silent defects in interpreting it. But it is smaller than 52 bits, so a signed 64 bit integer or double-precision float type are safe for storing this identifier. Returned only in getChat.
+ * @property ChatLocation|null    $location                     (Optional). For supergroups, the location to which the supergroup is connected. Returned only in getChat.
  */
 class Chat extends BaseObject
 {
@@ -31,9 +37,10 @@ class Chat extends BaseObject
     public function relations()
     {
         return [
-            'photo' => InputMedia::class,
+            'photo'          => InputMedia::class,
             'pinned_message' => Message::class,
-            'permissions' => ChatPermissions::class,
+            'permissions'    => ChatPermissions::class,
+            'location'       => ChatLocation::class,
         ];
     }
 }

--- a/src/Objects/ChatInviteLink.php
+++ b/src/Objects/ChatInviteLink.php
@@ -5,16 +5,17 @@ namespace Telegram\Bot\Objects;
 /**
  * Class ChatInviteLink.
  *
+ * @link https://core.telegram.org/bots/api#chatinvitelink
  *
  * @property string         $invite_link                The invite link. If the link was created by another chat administrator, then the second part of the link will be replaced with “…”.
  * @property User           $creator                    Creator of the link.
  * @property bool           $creates_join_request       True, if users joining the chat via the link need to be approved by chat administrators.
  * @property bool           $is_primary                 True, if the link is primary.
  * @property bool           $is_revoked                 True, if the link is revoked.
- * @property string|null    $name                       Optional. Invite link name.
- * @property int|null       $expire_date                Optional. Point in time (Unix timestamp) when the link will expire or has been expired.
- * @property int|null       $member_limit               Optional. The maximum number of users that can be members of the chat simultaneously after joining the chat via this invite link; 1-99999.
- * @property int|null       $pending_join_request_count Optional. Number of pending join requests created using this link.
+ * @property string|null    $name                       (Optional). Invite link name.
+ * @property int|null       $expire_date                (Optional). Point in time (Unix timestamp) when the link will expire or has been expired.
+ * @property int|null       $member_limit               (Optional). Maximum number of users that can be members of the chat simultaneously after joining the chat via this invite link; 1-99999.
+ * @property int|null       $pending_join_request_count (Optional). Number of pending join requests created using this link.
  */
 class ChatInviteLink extends BaseObject
 {

--- a/src/Objects/ChatJoinRequest.php
+++ b/src/Objects/ChatJoinRequest.php
@@ -5,6 +5,7 @@ namespace Telegram\Bot\Objects;
 /**
  * Class ChatJoinRequest.
  *
+ * @link https://core.telegram.org/bots/api#chatjoinrequest
  *
  * @property Chat                   $chat           Chat to which the request was sent.
  * @property User                   $from           User that sent the join request.

--- a/src/Objects/ChatLocation.php
+++ b/src/Objects/ChatLocation.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Telegram\Bot\Objects;
+
+/**
+ * Class ChatLocation.
+ *
+ * @link https://core.telegram.org/bots/api#chatlocation
+ *
+ * @property Location $location          The location to which the supergroup is connected. Can't be a live location.
+ * @property string   $address           Location address; 1-64 characters, as defined by the chat owner
+ */
+class ChatLocation extends BaseObject
+{
+    public function relations()
+    {
+        return [
+            'location' => Location::class,
+        ];
+    }
+}

--- a/src/Objects/ChatMember.php
+++ b/src/Objects/ChatMember.php
@@ -5,9 +5,12 @@ namespace Telegram\Bot\Objects;
 /**
  * Class ChatMember.
  *
+ * @link https://core.telegram.org/bots/api#chatmember
+ *
  * @property User        $user                            Information about the user.
  * @property string      $status                          The member's status in the chat. Can be “creator”, “administrator”, “member”, “left” or “kicked”
  * @property string|null $customTitle                     (Optional). Owner and administrators only. Custom title for this user
+ * @property bool|null   $isAnonymous                     (Optional). Owner and administrators only. True, if the user's presence in the chat is hidden
  * @property int|null    $untilDate                       (Optional). Restricted and kicked only. Date when restrictions will be lifted for this user, unix time
  * @property bool|null   $canBeEdited                     (Optional). Administrators only. True, if the bot is allowed to edit administrator privileges of that user
  * @property bool|null   $canPostMessages                 (Optional). Administrators only. True, if the administrator can post in the channel, channels only
@@ -23,8 +26,8 @@ namespace Telegram\Bot\Objects;
  * @property bool|null   $canSendPolls                    (Optional). Restricted only. True, if the user is allowed to send polls
  * @property bool|null   $canSendOtherMessages            (Optional). Restricted only. True, if the user can send animations, games, stickers and use inline bots, implies can_send_media_messages
  * @property bool|null   $canAddWebPagePreviews           (Optional). Restricted only. True, if user may add web page previews to his messages, implies can_send_media_messages
- *
- * @link https://core.telegram.org/bots/api#chatmember
+ * @property bool|null   $canManageVoiceChats             (Optional). Restricted only. True, if user may manage voice chats
+ * @property bool|null   $canManageChat                   (Optional). Restricted only. True, if the administrator can access the chat event log, chat statistics, message statistics in channels, see channel members, see anonymous administrators in supergroups and ignore slow mode. Implied by any other administrator privilege
  */
 class ChatMember extends BaseObject
 {

--- a/src/Objects/ChatMemberUpdated.php
+++ b/src/Objects/ChatMemberUpdated.php
@@ -5,13 +5,14 @@ namespace Telegram\Bot\Objects;
 /**
  * Class ChatMemberUpdated.
  *
+ * @link https://core.telegram.org/bots/api#message
  *
  * @property Chat                   $chat               Chat the user belongs to.
  * @property User                   $from               Performer of the action, which resulted in the change.
  * @property int                    $date               Date the change was done in Unix time.
  * @property ChatMember             $old_chat_member    Previous information about the chat member.
- * @property ChatMember             $new_chat_member    Previous information about the chat member.
- * @property ChatInviteLink|null    $invite_link        Optional. Chat invite link, which was used by the user to join the chat; for joining by invite link events only.
+ * @property ChatMember             $new_chat_member    New information about the chat member.
+ * @property ChatInviteLink|null    $invite_link        (Optional). Chat invite link, which was used by the user to join the chat; for joining by invite link events only.
  */
 class ChatMemberUpdated extends BaseObject
 {
@@ -21,11 +22,11 @@ class ChatMemberUpdated extends BaseObject
     public function relations()
     {
         return [
-            'chat' => Chat::class,
-            'from' => User::class,
+            'chat'            => Chat::class,
+            'from'            => User::class,
             'old_chat_member' => ChatMember::class,
             'new_chat_member' => ChatMember::class,
-            'invite_link' => ChatInviteLink::class,
+            'invite_link'     => ChatInviteLink::class,
         ];
     }
 }

--- a/src/Objects/ChatPermissions.php
+++ b/src/Objects/ChatPermissions.php
@@ -5,6 +5,8 @@ namespace Telegram\Bot\Objects;
 /**
  * Class ChatPermissions.
  *
+ * @link https://core.telegram.org/bots/api#chatpermissions
+ *
  * @property bool|null $canSendMessages       (Optional). True, if the user is allowed to send text messages, contacts, locations and venues
  * @property bool|null $canSendMediaMessages  (Optional). True, if the user is allowed to send audios, documents, photos, videos, video notes and voice notes, implies can_send_messages
  * @property bool|null $canSendPolls          (Optional). True, if the user is allowed to send polls, implies can_send_messages

--- a/src/Objects/ChatPermissions.php
+++ b/src/Objects/ChatPermissions.php
@@ -23,8 +23,6 @@ class ChatPermissions extends BaseObject
      */
     public function relations()
     {
-        return [
-            'user' => User::class,
-        ];
+        return [];
     }
 }

--- a/src/Objects/ChatPhoto.php
+++ b/src/Objects/ChatPhoto.php
@@ -5,6 +5,7 @@ namespace Telegram\Bot\Objects;
 /**
  * Class ChatPhoto.
  *
+ * @link https://core.telegram.org/bots/api#chatphoto
  *
  * @property string $smallFileId         Unique file identifier of small (160x160) chat photo. This file_id can be used only for photo download. This file_id can be used only for photo download and only for as long as the photo is not changed.
  * @property string $smallFileUniqueId   Unique file identifier of small (160x160) chat photo, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.

--- a/src/Objects/ChosenInlineResult.php
+++ b/src/Objects/ChosenInlineResult.php
@@ -5,6 +5,7 @@ namespace Telegram\Bot\Objects;
 /**
  * Class ChosenInlineResult.
  *
+ * @link https://core.telegram.org/bots/api#choseninlineresult
  *
  * @property string        $resultId           The unique identifier for the result that was chosen.
  * @property User          $from               The user that chose the result.
@@ -22,8 +23,13 @@ class ChosenInlineResult extends BaseObject
     public function relations()
     {
         return [
-            'from' => User::class,
+            'from'     => User::class,
             'location' => Location::class,
         ];
+    }
+
+    public function objectType(): ?string
+    {
+        return $this->findType(['location', 'inline_message_id']);
     }
 }

--- a/src/Objects/Contact.php
+++ b/src/Objects/Contact.php
@@ -5,6 +5,7 @@ namespace Telegram\Bot\Objects;
 /**
  * Class Contact.
  *
+ * @link https://core.telegram.org/bots/api#contact
  *
  * @property string      $phoneNumber    Contact's phone number.
  * @property string      $firstName      Contact's first name.

--- a/src/Objects/Dice.php
+++ b/src/Objects/Dice.php
@@ -7,7 +7,10 @@ namespace Telegram\Bot\Objects;
  *
  * (Yes, we're aware of the “proper” singular of die. But it's awkward, and we decided to help it change. One dice at a time!)
  *
- * @property int $value     Value of the dice, 1-6
+ * @link https://core.telegram.org/bots/api#dice
+ *
+ * @property string $emoji  Emoji on which the dice throw animation is based
+ * @property int    $value  Value of the dice, 1-6 for “🎲”, “🎯” and “🎳” base emoji, 1-5 for “🏀” and “⚽” base emoji, 1-64 for “🎰” base emoji
  */
 class Dice extends BaseObject
 {

--- a/src/Objects/Document.php
+++ b/src/Objects/Document.php
@@ -5,6 +5,7 @@ namespace Telegram\Bot\Objects;
 /**
  * Class Document.
  *
+ * @link https://core.telegram.org/bots/api#document
  *
  * @property string         $fileId           Unique file identifier.
  * @property string         $fileUniqueId     Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.

--- a/src/Objects/File.php
+++ b/src/Objects/File.php
@@ -5,6 +5,7 @@ namespace Telegram\Bot\Objects;
 /**
  * Class File.
  *
+ * @link https://core.telegram.org/bots/api#file
  *
  * @property string      $fileId         Unique identifier for this file.
  * @property string      $fileUniqueId   Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.

--- a/src/Objects/Game.php
+++ b/src/Objects/Game.php
@@ -5,14 +5,14 @@ namespace Telegram\Bot\Objects;
 /**
  * Class Game.
  *
+ * @link https://core.telegram.org/bots/api#game
+ *
  * @property string               $title        Title of the game.
  * @property string               $description  Description of the game.
  * @property PhotoSize[]          $photo        Photo that will be displayed in the game message in chats.
  * @property string|null          $text         (Optional). Brief description of the game or high scores included in the game message. Can be automatically edited to include current high scores for the game when the bot calls setGameScore, or manually edited using editMessageText. 0-4096 characters.
  * @property MessageEntity[]|null $textEntities (Optional). Special entities that appear in text, such as usernames, URLs, bot commands, etc.
  * @property Animation|null       $animation    (Optional). Animation that will be displayed in the game message in chats. Upload via BotFather.
- *
- * @link https://core.telegram.org/bots/api#game
  */
 class Game extends BaseObject
 {

--- a/src/Objects/GameHighScore.php
+++ b/src/Objects/GameHighScore.php
@@ -5,6 +5,8 @@ namespace Telegram\Bot\Objects;
 /**
  * Class GameHighScore.
  *
+ * @link https://core.telegram.org/bots/api#gamehighscore
+ *
  * @property int  $position Position in high score table for the game.
  * @property User $user     User
  * @property int  $score    Score

--- a/src/Objects/InlineQuery.php
+++ b/src/Objects/InlineQuery.php
@@ -11,6 +11,7 @@ namespace Telegram\Bot\Objects;
  * @property Location|null $location   (Optional). Sender location, only for bots that request user location.
  * @property string        $query      Text of the query.
  * @property string        $offset     Offset of the results to be returned.
+ * @property string|null   $chatType   (Optional). Type of the chat, from which the inline query was sent. Can be either “sender” for a private chat with the inline query sender, “private”, “group”, “supergroup”, or “channel”. The chat type should be always known for requests sent from official clients and most third-party clients, unless the request was sent from a secret chat
  *
  * @link https://core.telegram.org/bots/api#inlinequery
  */
@@ -25,5 +26,10 @@ class InlineQuery extends BaseObject
             'from'     => User::class,
             'location' => Location::class,
         ];
+    }
+
+    public function objectType(): ?string
+    {
+        return $this->findType(['location']);
     }
 }

--- a/src/Objects/InlineQuery/InlineQueryResultArticle.php
+++ b/src/Objects/InlineQuery/InlineQueryResultArticle.php
@@ -5,19 +5,21 @@ namespace Telegram\Bot\Objects\InlineQuery;
 /**
  * Class InlineQueryResultArticle.
  *
+ * Represents a link to an article or web page.
+ *
  * <code>
- * $params = [
- *   'id'                       => '',
- *   'title'                    => '',
- *   'input_message_content'    => '',
- *   'reply_markup'             => '',
- *   'url'                      => '',
- *   'hide_url'                 => '',
- *   'description'              => '',
- *   'thumb_url'                => '',
- *   'thumb_width'              => '',
- *   'thumb_height'             => '',
- * ];
+ * [
+ *   'id'                     => '', // string                 - Required. Unique identifier for this result, 1-64 Bytes
+ *   'title'                  => '', // string                 - Required. Title of the result
+ *   'input_message_content'  => '', // InputMessageContent    - Required. Content of the message to be sent.
+ *   'reply_markup'           => '', // InlineKeyboardMarkup   - (Optional). Inline keyboard attached to the message
+ *   'url'                    => '', // string                 - (Optional). URL of the result
+ *   'hide_url'               => '', // bool                   - (Optional). Pass True, if you don't want the URL to be shown in the message
+ *   'description'            => '', // string                 - (Optional). Short description of the result
+ *   'thumb_url'              => '', // string                 - (Optional). Url of the thumbnail for the result
+ *   'thumb_width'            => '', // int                    - (Optional). Thumbnail width
+ *   'thumb_height'           => '', // int                    - (Optional). Thumbnail height
+ * ]
  * </code>
  *
  * @link https://core.telegram.org/bots/api#inlinequeryresultarticle

--- a/src/Objects/InlineQuery/InlineQueryResultAudio.php
+++ b/src/Objects/InlineQuery/InlineQueryResultAudio.php
@@ -5,18 +5,23 @@ namespace Telegram\Bot\Objects\InlineQuery;
 /**
  * Class InlineQueryResultAudio.
  *
+ * Represents a link to an MP3 audio file. By default, this audio file will be sent by the user.
+ * Alternatively, you can use input_message_content to send a message with the specified content
+ * instead of the audio.
+ *
  * <code>
- * $params = [
- *   'id'                         => '',
- *   'audio_url'                  => '',
- *   'title'                      => '',
- *   'caption'                    => '',
- *   'parse_mode'                 => '',
- *   'performer'                  => '',
- *   'audio_duration'             => '',
- *   'reply_markup'               => '',
- *   'input_message_content'      => '',
- * ];
+ * [
+ *   'id'                     => '',  //  string                 - Required. Unique identifier for this result, 1-64 bytes
+ *   'audio_url'              => '',  //  string                 - Required. A valid URL for the audio file
+ *   'title'                  => '',  //  string                 - Required. Title
+ *   'caption'                => '',  //  string                 - (Optional). Caption, 0-200 characters
+ *   'parse_mode'             => '',  //  string                 - (Optional). Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in the media caption.
+ *   'caption_entities'       => '',  //  array                  - (Optional). List of special entities that appear in the caption, which can be specified instead of parse_mode
+ *   'performer'              => '',  //  string                 - (Optional). Performer
+ *   'audio_duration'         => '',  //  int                    - (Optional). Audio duration in seconds
+ *   'reply_markup'           => '',  //  InlineKeyboardMarkup   - (Optional). Inline keyboard attached to the message
+ *   'input_message_content'  => '',  //  InputMessageContent    - (Optional). Content of the message to be sent instead of the photo
+ * ]
  * </code>
  *
  * @link https://core.telegram.org/bots/api#inlinequeryresultaudio

--- a/src/Objects/InlineQuery/InlineQueryResultCachedAudio.php
+++ b/src/Objects/InlineQuery/InlineQueryResultCachedAudio.php
@@ -5,15 +5,20 @@ namespace Telegram\Bot\Objects\InlineQuery;
 /**
  * Class InlineQueryResultCachedAudio.
  *
+ * Represents a link to an MP3 audio file stored on the Telegram servers. By default, this audio file will be sent
+ * by the user. Alternatively, you can use input_message_content to send a message with the specified content
+ * instead of the audio.
+ *
  * <code>
- * $params = [
- *   'id'                         => '',
- *   'audio_file_id'              => '',
- *   'caption'                    => '',
- *   'parse_mode'                 => '',
- *   'reply_markup'               => '',
- *   'input_message_content'      => '',
- * ];
+ * [
+ *   'id'                     => '',  //  string                - Required. Unique identifier for this result, 1-64 bytes
+ *   'audio_file_id'          => '',  //  string                - Required. A valid file identifier for the audio file
+ *   'caption'                => '',  //  string                - (Optional). Caption, 0-200 characters
+ *   'parse_mode'             => '',  //  string                - (Optional). Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in the media caption.
+ *   'caption_entities'       => '',  //  array                 - (Optional). List of special entities that appear in the caption, which can be specified instead of parse_mode
+ *   'reply_markup'           => '',  //  InlineKeyboardMarkup  - (Optional). Inline keyboard attached to the message
+ *   'input_message_content'  => '',  //  InputMessageContent   - (Optional). Content of the message to be sent instead of the photo
+ * ]
  * </code>
  *
  * @link https://core.telegram.org/bots/api#inlinequeryresultcachedaudio

--- a/src/Objects/InlineQuery/InlineQueryResultCachedDocument.php
+++ b/src/Objects/InlineQuery/InlineQueryResultCachedDocument.php
@@ -5,17 +5,22 @@ namespace Telegram\Bot\Objects\InlineQuery;
 /**
  * Class InlineQueryResultCachedDocument.
  *
+ * Represents a link to a file stored on the Telegram servers. By default, this file will be sent by the user with
+ * an optional caption. Alternatively, you can use input_message_content to send a message with the specified content
+ * instead of the file.
+ *
  * <code>
- * $params = [
- *   'id'                       => '',
- *   'title'                    => '',
- *   'document_file_id'         => '',
- *   'description'              => '',
- *   'caption'                  => '',
- *   'parse_mode'               => '',
- *   'reply_markup'             => '',
- *   'input_message_content'    => '',
- * ];
+ * [
+ *   'id'                     => '',  //  string                - Required. Unique identifier for this result, 1-64 bytes
+ *   'title'                  => '',  //  string                - Required. Title for the result
+ *   'document_file_id'       => '',  //  string                - Required. A valid file identifier for the file
+ *   'description'            => '',  //  string                - (Optional). Short description of the result
+ *   'caption'                => '',  //  string                - (Optional). Caption of the document to be sent, 0-200 characters
+ *   'parse_mode'             => '',  //  string                - (Optional). Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in the media caption.
+ *   'caption_entities'       => '',  //  array                 - (Optional). List of special entities that appear in the caption, which can be specified instead of parse_mode
+ *   'reply_markup'           => '',  //  InlineKeyboardMarkup  - (Optional). Inline keyboard attached to the message
+ *   'input_message_content'  => '',  //  InputMessageContent   - (Optional). Content of the message to be sent instead of the file
+ * ]
  * </code>
  *
  * @link https://core.telegram.org/bots/api#inlinequeryresultcacheddocument

--- a/src/Objects/InlineQuery/InlineQueryResultCachedGif.php
+++ b/src/Objects/InlineQuery/InlineQueryResultCachedGif.php
@@ -5,16 +5,21 @@ namespace Telegram\Bot\Objects\InlineQuery;
 /**
  * Class InlineQueryResultCachedGif.
  *
+ * Represents a link to an animated GIF file stored on the Telegram servers. By default, this animated GIF file will
+ * be sent by the user with an optional caption. Alternatively, you can use input_message_content to send a message
+ * with specified content instead of the animation.
+ *
  * <code>
- * $params = [
- *   'id'                       => '',
- *   'gif_file_id'              => '',
- *   'title'                    => '',
- *   'caption'                  => '',
- *   'parse_mode'               => '',
- *   'reply_markup'             => '',
- *   'input_message_content'    => '',
- * ];
+ * [
+ *   'id'                     => '',  //  string                - Required. Unique identifier for this result, 1-64 bytes
+ *   'gif_file_id'            => '',  //  string                - Required. A valid file identifier for the GIF file
+ *   'title'                  => '',  //  string                - (Optional). Title for the result
+ *   'caption'                => '',  //  string                - (Optional). Caption of the GIF file to be sent, 0-200 characters
+ *   'parse_mode'             => '',  //  string                - (Optional). Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in the media caption.
+ *   'caption_entities'       => '',  //  array                 - (Optional). List of special entities that appear in the caption, which can be specified instead of parse_mode
+ *   'reply_markup'           => '',  //  InlineKeyboardMarkup  - (Optional). Inline keyboard attached to the message
+ *   'input_message_content'  => '',  //  InputMessageContent   - (Optional). Content of the message to be sent instead of the photo
+ * ]
  * </code>
  *
  * @link https://core.telegram.org/bots/api#inlinequeryresultcachedgif

--- a/src/Objects/InlineQuery/InlineQueryResultCachedMpeg4Gif.php
+++ b/src/Objects/InlineQuery/InlineQueryResultCachedMpeg4Gif.php
@@ -5,16 +5,21 @@ namespace Telegram\Bot\Objects\InlineQuery;
 /**
  * Class InlineQueryResultCachedMpeg4Gif.
  *
+ * Represents a link to a video animation (H.264/MPEG-4 AVC video without sound) stored on the Telegram servers.
+ * By default, this animated MPEG-4 file will be sent by the user with an optional caption. Alternatively, you can use
+ * input_message_content to send a message with the specified content instead of the animation.
+ *
  * <code>
- * $params = [
- *   'id'                         => '',
- *   'mpeg4_file_id'              => '',
- *   'title'                      => '',
- *   'caption'                    => '',
- *   'parse_mode'                 => '',
- *   'reply_markup'               => '',
- *   'input_message_content'      => '',
- * ];
+ * [
+ *   'id'                     => '',  //  string                - Required. Unique identifier for this result, 1-64 bytes
+ *   'mpeg4_file_id'          => '',  //  string                - Required. A valid file identifier for the MP4 file
+ *   'title'                  => '',  //  string                - (Optional). Title for the result
+ *   'caption'                => '',  //  string                - (Optional). Caption of the MPEG-4 file to be sent, 0-200 characters
+ *   'parse_mode'             => '',  //  string                - (Optional). Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in the media caption.
+ *   'caption_entities'       => '',  //  array                 - (Optional). List of special entities that appear in the caption, which can be specified instead of parse_mode
+ *   'reply_markup'           => '',  //  InlineKeyboardMarkup  - (Optional). Inline keyboard attached to the message
+ *   'input_message_content'  => '',  //  InputMessageContent   - (Optional). Content of the message to be sent instead of the photo
+ * ]
  * </code>
  *
  * @link https://core.telegram.org/bots/api#inlinequeryresultcachedmpeg4gif

--- a/src/Objects/InlineQuery/InlineQueryResultCachedPhoto.php
+++ b/src/Objects/InlineQuery/InlineQueryResultCachedPhoto.php
@@ -5,17 +5,22 @@ namespace Telegram\Bot\Objects\InlineQuery;
 /**
  * Class InlineQueryResultCachedPhoto.
  *
+ * Represents a link to a photo stored on the Telegram servers. By default, this photo will be sent by the user with
+ * an optional caption. Alternatively, you can use input_message_content to send a message with the specified content
+ * instead of the photo.
+ *
  * <code>
- * $params = [
- *   'id'                       => '',
- *   'photo_file_id'            => '',
- *   'title'                    => '',
- *   'description'              => '',
- *   'caption'                  => '',
- *   'parse_mode'               => '',
- *   'reply_markup'             => '',
- *   'input_message_content'    => '',
- * ];
+ * [
+ *   'id'                     => '',  //  string                - Required. Unique identifier for this result, 1-64 Bytes
+ *   'photo_file_id'          => '',  //  string                - Required. A valid file identifier of the photo
+ *   'title'                  => '',  //  string                - (Optional). Title for the result
+ *   'description'            => '',  //  string                - (Optional). Short description of the result
+ *   'caption'                => '',  //  string                - (Optional). Caption of the photo to be sent, 0-200 characters
+ *   'parse_mode'             => '',  //  string                - (Optional). Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in the media caption.
+ *   'caption_entities'       => '',  //  array                 - (Optional). List of special entities that appear in the caption, which can be specified instead of parse_mode
+ *   'reply_markup'           => '',  //  InlineKeyboardMarkup  - (Optional). Inline keyboard attached to the message
+ *   'input_message_content'  => '',  //  InputMessageContent   - (Optional). Content of the message to be sent instead of the photo
+ * ]
  * </code>
  *
  * @link https://core.telegram.org/bots/api#inlinequeryresultcachedphoto

--- a/src/Objects/InlineQuery/InlineQueryResultCachedSticker.php
+++ b/src/Objects/InlineQuery/InlineQueryResultCachedSticker.php
@@ -3,15 +3,17 @@
 namespace Telegram\Bot\Objects\InlineQuery;
 
 /**
- * Class InlineQueryResultCachedsticker.
+ * Class InlineQueryResultCachedSticker.
  *
+ * Represents a link to a sticker stored on the Telegram servers. By default, this sticker will be sent by the user.
+ * Alternatively, you can use input_message_content to send a message with the specified content instead of the sticker.
  * <code>
- * $params = [
- *   'id'                       => '',
- *   'sticker_file_id'          => '',
- *   'reply_markup'             => '',
- *   'input_message_content'    => '',
- * ];
+ * [
+ *   'id'                     => '',  //  string                - Required. Unique identifier for this result, 1-64 Bytes
+ *   'sticker_file_id'        => '',  //  string                - Required. A valid file identifier of the sticker
+ *   'reply_markup'           => '',  //  InlineKeyboardMarkup  - (Optional). Inline keyboard attached to the message
+ *   'input_message_content'  => '',  //  InputMessageContent   - (Optional). Content of the message to be sent instead of the photo
+ * ]
  * </code>
  *
  * @link https://core.telegram.org/bots/api#inlinequeryresultcachedsticker

--- a/src/Objects/InlineQuery/InlineQueryResultCachedVideo.php
+++ b/src/Objects/InlineQuery/InlineQueryResultCachedVideo.php
@@ -5,17 +5,22 @@ namespace Telegram\Bot\Objects\InlineQuery;
 /**
  * Class InlineQueryResultCachedVideo.
  *
+ * Represents a link to a video file stored on the Telegram servers. By default, this video file will be sent by the
+ * user with an optional caption. Alternatively, you can use input_message_content to send a message with the
+ * specified content instead of the video.
+ *
  * <code>
- * $params = [
- *   'id'                       => '',
- *   'video_file_id             => '',
- *   'title'                    => '',
- *   'description'              => '',
- *   'caption'                  => '',
- *   'parse_mode'               => '',
- *   'reply_markup'             => '',
- *   'input_message_content'    => '',
- * ];
+ * [
+ *   'id'                     => '',  //  string                - Required. Unique identifier for this result, 1-64 bytes
+ *   'video_file_id           => '',  //  string                - Required. A valid file identifier for the video file
+ *   'title'                  => '',  //  string                - Required. Title for the result
+ *   'description'            => '',  //  string                - (Optional). Short description of the result
+ *   'caption'                => '',  //  string                - (Optional). Caption of the video to be sent, 0-200 characters
+ *   'parse_mode'             => '',  //  string                - (Optional). Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in the media caption.
+ *   'caption_entities'       => '',  //  array                 - (Optional). List of special entities that appear in the caption, which can be specified instead of parse_mode
+ *   'reply_markup'           => '',  //  InlineKeyboardMarkup  - (Optional). Inline keyboard attached to the message
+ *   'input_message_content'  => '',  //  InputMessageContent   - (Optional). Content of the message to be sent instead of the photo
+ * ]
  * </code>
  *
  * @link https://core.telegram.org/bots/api#inlinequeryresultcachedvideo

--- a/src/Objects/InlineQuery/InlineQueryResultCachedVoice.php
+++ b/src/Objects/InlineQuery/InlineQueryResultCachedVoice.php
@@ -5,16 +5,21 @@ namespace Telegram\Bot\Objects\InlineQuery;
 /**
  * Class InlineQueryResultCachedVoice.
  *
+ * Represents a link to a voice message stored on the Telegram servers. By default, this voice message will be sent
+ * by the user. Alternatively, you can use input_message_content to send a message with the specified content instead
+ * of the voice message.
+ *
  * <code>
- * $params = [
- *   'id'                         => '',
- *   'voice_file_id'              => '',
- *   'title'                      => '',
- *   'caption'                    => '',
- *   'parse_mode'                 => '',
- *   'reply_markup'               => '',
- *   'input_message_content'      => '',
- * ];
+ * [
+ *   'id'                     => '',  //  string                - Required. Unique identifier for this result, 1-64 bytes
+ *   'voice_file_id'          => '',  //  string                - Required. A valid file identifier for the voice message
+ *   'title'                  => '',  //  string                - Required. Voice message title
+ *   'caption'                => '',  //  string                - (Optional). Caption, 0-200 characters
+ *   'parse_mode'             => '',  //  string                - (Optional). Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in the media caption.
+ *   'caption_entities'       => '',  //  array                 - (Optional). List of special entities that appear in the caption, which can be specified instead of parse_mode
+ *   'reply_markup'           => '',  //  InlineKeyboardMarkup  - (Optional). Inline keyboard attached to the message
+ *   'input_message_content'  => '',  //  InputMessageContent   - (Optional). Content of the message to be sent instead of the photo
+ * ]
  * </code>
  *
  * @link https://core.telegram.org/bots/api#inlinequeryresultcachedvoice

--- a/src/Objects/InlineQuery/InlineQueryResultContact.php
+++ b/src/Objects/InlineQuery/InlineQueryResultContact.php
@@ -5,19 +5,22 @@ namespace Telegram\Bot\Objects\InlineQuery;
 /**
  * Class InlineQueryResultContact.
  *
+ * Represents a contact with a phone number. By default, this contact will be sent by the user.
+ * Alternatively, you can use input_message_content to send a message with the specified content instead of the contact.
+ *
  * <code>
- * $params = [
- *   'id'                       => '',
- *   'phone_number'             => '',
- *   'first_name'               => '',
- *   'last_name'                => '',
- *   'vcard'                    => '',
- *   'reply_markup'             => '',
- *   'input_message_content'    => '',
- *   'thumb_url'                => '',
- *   'thumb_width'              => '',
- *   'thumb_height'             => '',
- * ];
+ * [
+ *   'id'                     => '',  //  string                - Required. Unique identifier for this result, 1-64 Bytes
+ *   'phone_number'           => '',  //  string                - Required. Contact's phone number
+ *   'first_name'             => '',  //  string                - Required. Contact's first name
+ *   'last_name'              => '',  //  string                - (Optional). Contact's last name
+ *   'vcard'                  => '',  //  string                - (Optional). Additional data about the contact in the form of a vCard, 0-2048 bytes
+ *   'reply_markup'           => '',  //  InlineKeyboardMarkup  - (Optional). Inline keyboard attached to the message
+ *   'input_message_content'  => '',  //  InputMessageContent   - (Optional). Content of the message to be sent instead of the contact
+ *   'thumb_url'              => '',  //  string                - (Optional). Url of the thumbnail for the result
+ *   'thumb_width'            => '',  //  int                   - (Optional). Thumbnail width
+ *   'thumb_height'           => '',  //  int                   - (Optional). Thumbnail height
+ * ]
  * </code>
  *
  * @link https://core.telegram.org/bots/api#inlinequeryresultcontact

--- a/src/Objects/InlineQuery/InlineQueryResultDocument.php
+++ b/src/Objects/InlineQuery/InlineQueryResultDocument.php
@@ -5,21 +5,26 @@ namespace Telegram\Bot\Objects\InlineQuery;
 /**
  * Class InlineQueryResultDocument.
  *
+ * Represents a link to a file. By default, this file will be sent by the user with an optional caption.
+ * Alternatively, you can use input_message_content to send a message with the specified content instead of the file.
+ * Currently, only .PDF and .ZIP files can be sent using this method.
+ *
  * <code>
- * $params = [
- *   'id'                       => '',
- *   'title'                    => '',
- *   'caption'                  => '',
- *   'parse_mode'               => '',
- *   'document_url'             => '',
- *   'mime_type'                => '',
- *   'description'              => '',
- *   'reply_markup'             => '',
- *   'input_message_content'    => '',
- *   'thumb_url'                => '',
- *   'thumb_width'              => '',
- *   'thumb_height'             => '',
- * ];
+ * [
+ *   'id'                     => '',  //  string                - Required. Unique identifier for this result, 1-64 bytes
+ *   'title'                  => '',  //  string                - Required. Title for the result
+ *   'caption'                => '',  //  string                - (Optional). Caption of the document to be sent, 0-200 characters
+ *   'parse_mode'             => '',  //  string                - (Optional). Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in the media caption.
+ *   'caption_entities'       => '',  //  array                 - (Optional). List of special entities that appear in the caption, which can be specified instead of parse_mode
+ *   'document_url'           => '',  //  string                - Required. A valid URL for the file
+ *   'mime_type'              => '',  //  string                - Required. Mime type of the content of the file, either “application/pdf” or “application/zip”
+ *   'description'            => '',  //  string                - (Optional). Short description of the result
+ *   'reply_markup'           => '',  //  InlineKeyboardMarkup  - (Optional). Inline keyboard attached to the message
+ *   'input_message_content'  => '',  //  InputMessageContent   - (Optional). Content of the message to be sent instead of the file
+ *   'thumb_url'              => '',  //  string                - (Optional). URL of the thumbnail (jpeg only) for the file
+ *   'thumb_width'            => '',  //  int                   - (Optional). Thumbnail width
+ *   'thumb_height'           => '',  //  int                   - (Optional). Thumbnail height
+ * ]
  * </code>
  *
  * @link https://core.telegram.org/bots/api#inlinequeryresultdocument

--- a/src/Objects/InlineQuery/InlineQueryResultGame.php
+++ b/src/Objects/InlineQuery/InlineQueryResultGame.php
@@ -5,12 +5,14 @@ namespace Telegram\Bot\Objects\InlineQuery;
 /**
  * Class InlineQueryResultGame.
  *
+ * Represents a Game.
+ *
  * <code>
- * $params = [
- *   'id'              => '',
- *   'game_short_name' => '',
- *   'reply_markup'    => '',
- * ];
+ * [
+ *   'id'               => '',  //  string                - Required. Unique identifier for this result, 1-64 Bytes.
+ *   'game_short_name'  => '',  //  string                - Required. Short name of the game.
+ *   'reply_markup'     => '',  //  InlineKeyboardMarkup  - (Optional). Inline keyboard attached to the message
+ * ]
  * </code>
  *
  * @link https://core.telegram.org/bots/api#inlinequeryresultgame

--- a/src/Objects/InlineQuery/InlineQueryResultGif.php
+++ b/src/Objects/InlineQuery/InlineQueryResultGif.php
@@ -5,20 +5,25 @@ namespace Telegram\Bot\Objects\InlineQuery;
 /**
  * Class InlineQueryResultGif.
  *
+ * Represents a link to an animated GIF file. By default, this animated GIF file will be sent by the user with
+ * optional caption. Alternatively, you can use input_message_content to send a message with the specified content
+ * instead of the animation.
+ *
  * <code>
- * $params = [
- *   'id'                       => '',
- *   'gif_url'                  => '',
- *   'gif_width'                => '',
- *   'gif_height'               => '',
- *   'gif_duration'             => '',
- *   'thumb_url'                => '',
- *   'title'                    => '',
- *   'caption'                  => '',
- *   'parse_mode'               => '',
- *   'reply_markup'             => '',
- *   'input_message_content'    => '',
- * ];
+ * [
+ *   'id'                     => '',  //  string                - Required. Unique identifier for this result, 1-64 bytes
+ *   'gif_url'                => '',  //  string                - Required. A valid URL for the GIF file. File size must not exceed 1MB
+ *   'gif_width'              => '',  //  int                   - (Optional). Width of the GIF
+ *   'gif_height'             => '',  //  int                   - (Optional). Height of the GIF
+ *   'gif_duration'           => '',  //  int                   - (Optional). Duration of the GIF
+ *   'thumb_url'              => '',  //  string                - Required. URL of the static thumbnail for the result (jpeg or gif)
+ *   'title'                  => '',  //  string                - (Optional). Title for the result
+ *   'caption'                => '',  //  string                - (Optional). Caption of the GIF file to be sent, 0-200 characters
+ *   'caption_entities'       => '',  //  array                 - (Optional). List of special entities that appear in the caption, which can be specified instead of parse_mode
+ *   'parse_mode'             => '',  //  string                - (Optional). Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in the media caption.
+ *   'reply_markup'           => '',  //  InlineKeyboardMarkup  - (Optional). Inline keyboard attached to the message
+ *   'input_message_content'  => '',  //  InputMessageContent   - (Optional). Content of the message to be sent instead of the photo
+ * ]
  * </code>
  *
  * @link https://core.telegram.org/bots/api#inlinequeryresultgif

--- a/src/Objects/InlineQuery/InlineQueryResultLocation.php
+++ b/src/Objects/InlineQuery/InlineQueryResultLocation.php
@@ -5,18 +5,25 @@ namespace Telegram\Bot\Objects\InlineQuery;
 /**
  * Class InlineQueryResultLocation.
  *
+ * Represents a location on a map. By default, the location will be sent by the user.
+ * Alternatively, you can use input_message_content to send a message with the specified content instead of the location.
+ *
  * <code>
- * $params = [
- *    'id'                      => '',
- *    'latitude'                => '',
- *    'longitude'               => '',
- *    'title'                   => '',
- *    'reply_markup'            => '',
- *    'input_message_content'   => '',
- *    'thumb_url'               => '',
- *    'thumb_width'             => '',
- *    'thumb_height'            => '',
- * ];
+ * [
+ *    'id'                     => '',  //  string                - Required. Unique identifier for this result, 1-64 Bytes
+ *    'latitude'               => '',  //  float                 - Required. Location latitude in degrees
+ *    'longitude'              => '',  //  float                 - Required. Location longitude in degrees
+ *    'title'                  => '',  //  string                - Required. Location title
+ *    'horizontal_accuracy'    => '',  //  float                 - (Optional). The radius of uncertainty for the location, measured in meters; 0-1500
+ *    'live_period'            => '',  //  int                   - (Optional). Period in seconds for which the location can be updated, should be between 60 and 86400.
+ *    'heading'                => '',  //  int                   - (Optional). For live locations, a direction in which the user is moving, in degrees. Must be between 1 and 360 if specified.
+ *    'proximity_alert_radius' => '',  //  int                   - (Optional). For live locations, a maximum distance for proximity alerts about approaching another chat member, in meters. Must be between 1 and 100000 if specified.
+ *    'reply_markup'           => '',  //  InlineKeyboardMarkup  - (Optional). Inline keyboard attached to the message
+ *    'input_message_content'  => '',  //  InputMessageContent   - (Optional). Content of the message to be sent instead of the location
+ *    'thumb_url'              => '',  //  string                - (Optional). Url of the thumbnail for the result
+ *    'thumb_width'            => '',  //  int                   - (Optional). Thumbnail width
+ *    'thumb_height'           => '',  //  int                   - (Optional). Thumbnail height
+ * ]
  * </code>
  *
  * @link https://core.telegram.org/bots/api#inlinequeryresultlocation

--- a/src/Objects/InlineQuery/InlineQueryResultMpeg4Gif.php
+++ b/src/Objects/InlineQuery/InlineQueryResultMpeg4Gif.php
@@ -5,20 +5,25 @@ namespace Telegram\Bot\Objects\InlineQuery;
 /**
  * Class InlineQueryResultMpeg4Gif.
  *
+ * Represents a link to a video animation (H.264/MPEG-4 AVC video without sound). By default, this animated MPEG-4
+ * file will be sent by the user with optional caption. Alternatively, you can use input_message_content to send a
+ * message with the specified content instead of the animation.
+ *
  * <code>
- * $params = [
- *   'id'                         => '',
- *   'mpeg4_url'                  => '',
- *   'mpeg4_width'                => '',
- *   'mpeg4_height'               => '',
- *   'mpeg4_duration'             => '',
- *   'thumb_url'                  => '',
- *   'title'                      => '',
- *   'caption'                    => '',
- *   'parse_mode'                 => '',
- *   'reply_markup'               => '',
- *   'input_message_content'      => '',
- * ];
+ * [
+ *   'id'                     => '',  //  string                - Required. Unique identifier for this result, 1-64 bytes
+ *   'mpeg4_url'              => '',  //  string                - Required. A valid URL for the MP4 file. File size must not exceed 1MB
+ *   'mpeg4_width'            => '',  //  int                   - (Optional). Video width
+ *   'mpeg4_height'           => '',  //  int                   - (Optional). Video height
+ *   'mpeg4_duration'         => '',  //  int                   - (Optional). Video duration
+ *   'thumb_url'              => '',  //  string                - Required. URL of the static thumbnail (jpeg or gif) for the result
+ *   'title'                  => '',  //  string                - (Optional). Title for the result
+ *   'caption'                => '',  //  string                - (Optional). Caption of the MPEG-4 file to be sent, 0-200 characters
+ *   'parse_mode'             => '',  //  string                - (Optional). Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in the media caption.
+ *   'caption_entities'       => '',  //  array                 - (Optional). List of special entities that appear in the caption, which can be specified instead of parse_mode
+ *   'reply_markup'           => '',  //  InlineKeyboardMarkup  - (Optional). Inline keyboard attached to the message
+ *   'input_message_content'  => '',  //  InputMessageContent   - (Optional). Content of the message to be sent instead of the photo
+ * ]
  * </code>
  *
  * @link https://core.telegram.org/bots/api#inlinequeryresultmpeg4gif

--- a/src/Objects/InlineQuery/InlineQueryResultPhoto.php
+++ b/src/Objects/InlineQuery/InlineQueryResultPhoto.php
@@ -5,20 +5,24 @@ namespace Telegram\Bot\Objects\InlineQuery;
 /**
  * Class InlineQueryResultPhoto.
  *
+ * Represents a link to a photo. By default, this photo will be sent by the user with optional caption. Alternatively,
+ * you can use input_message_content to send a message with the specified content instead of the photo.
+ *
  * <code>
- * $params = [
- *   'id'                       => '',
- *   'photo_url'                => '',
- *   'thumb_url'                => '',
- *   'photo_width'              => '',
- *   'photo_height'             => '',
- *   'title'                    => '',
- *   'description'              => '',
- *   'caption'                  => '',
- *   'parse_mode'               => '',
- *   'reply_markup'             => '',
- *   'input_message_content'    => '',
- * ];
+ * [
+ *   'id'                     => '',  //  string                - Required. Unique identifier for this result, 1-64 Bytes
+ *   'photo_url'              => '',  //  string                - Required. A valid URL of the photo. Photo must be in jpeg format. Photo size must not exceed 5MB
+ *   'thumb_url'              => '',  //  string                - Required. URL of the thumbnail for the photo
+ *   'photo_width'            => '',  //  int                   - (Optional). Width of the photo
+ *   'photo_height'           => '',  //  int                   - (Optional). Height of the photo
+ *   'title'                  => '',  //  string                - (Optional). Title for the result
+ *   'description'            => '',  //  string                - (Optional). Short description of the result
+ *   'caption'                => '',  //  string                - (Optional). Caption of the photo to be sent, 0-200 characters
+ *   'parse_mode'             => '',  //  string                - (Optional). Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in the media caption.
+ *   'caption_entities'       => '',  //  array                 - (Optional). List of special entities that appear in the caption, which can be specified instead of parse_mode
+ *   'reply_markup'           => '',  //  InlineKeyboardMarkup  - (Optional). Inline keyboard attached to the message
+ *   'input_message_content'  => '',  //  InputMessageContent   - (Optional). Content of the message to be sent instead of the photo
+ * ]
  * </code>
  *
  * @link https://core.telegram.org/bots/api#inlinequeryresultphoto

--- a/src/Objects/InlineQuery/InlineQueryResultVenue.php
+++ b/src/Objects/InlineQuery/InlineQueryResultVenue.php
@@ -5,21 +5,26 @@ namespace Telegram\Bot\Objects\InlineQuery;
 /**
  * Class InlineQueryResultVenue.
  *
+ * Represents a venue. By default, the venue will be sent by the user. Alternatively, you can use
+ * input_message_content to send a message with the specified content instead of the venue.
+ *
  * <code>
- * $params = [
- *   'id'                       => '',
- *   'latitude'                 => '',
- *   'longitude'                => '',
- *   'title'                    => '',
- *   'address'                  => '',
- *   'foursquare_id'            => '',
- *   'foursquare_type'          => '',
- *   'reply_markup'             => '',
- *   'input_message_content'    => '',
- *   'thumb_url'                => '',
- *   'thumb_width'              => '',
- *   'thumb_height'             => '',
- * ];
+ * [
+ *   'id'                     => '',  //  string                - Required. Unique identifier for this result, 1-64 Bytes
+ *   'latitude'               => '',  //  float                 - Required. Latitude of the venue location in degrees
+ *   'longitude'              => '',  //  float                 - Required. Longitude of the venue location in degrees
+ *   'title'                  => '',  //  string                - Required. Title of the venue
+ *   'address'                => '',  //  string                - Required. Address of the venue
+ *   'foursquare_id'          => '',  //  string                - (Optional). Foursquare identifier of the venue if known
+ *   'foursquare_type'        => '',  //  string                - (Optional). Foursquare type of the venue, if known. (For example, “arts_entertainment/default”, “arts_entertainment/aquarium” or “food/icecream”.)
+ *   'google_place_id'        => '',  //  string                - (Optional). Google Places identifier of the venue
+ *   'google_place_type'      => '',  //  string                - (Optional). Google Places type of the venue.
+ *   'reply_markup'           => '',  //  InlineKeyboardMarkup  - (Optional). Inline keyboard attached to the message
+ *   'input_message_content'  => '',  //  InputMessageContent   - (Optional). Content of the message to be sent instead of the venue
+ *   'thumb_url'              => '',  //  string                - (Optional). Url of the thumbnail for the result
+ *   'thumb_width'            => '',  //  int                   - (Optional). Thumbnail width
+ *   'thumb_height'           => '',  //  int                   - (Optional). Thumbnail height
+ * ]
  * </code>
  *
  * @link https://core.telegram.org/bots/api#inlinequeryresultvenue

--- a/src/Objects/InlineQuery/InlineQueryResultVideo.php
+++ b/src/Objects/InlineQuery/InlineQueryResultVideo.php
@@ -5,22 +5,30 @@ namespace Telegram\Bot\Objects\InlineQuery;
 /**
  * Class InlineQueryResultVideo.
  *
+ * Represents a link to a page containing an embedded video player or a video file. By default,
+ * this video file will be sent by the user with an optional caption. Alternatively, you can
+ * use input_message_content to send a message with the specified content instead of the video.
+ *
+ * If an InlineQueryResultVideo message contains an embedded video (e.g., YouTube), you must
+ * replace its content using input_message_content.
+ *
  * <code>
- * $params = [
- *   'id'                       => '',
- *   'video_url'                => '',
- *   'mime_type'                => '',
- *   'thumb_url'                => '',
- *   'title'                    => '',
- *   'caption'                  => '',
- *   'parse_mode'               => '',
- *   'video_width'              => '',
- *   'video_height'             => '',
- *   'video_duration'           => '',
- *   'description'              => '',
- *   'reply_markup'             => '',
- *   'input_message_content'    => '',
- * ];
+ * [
+ *   'id'                     => '',  //  string                - Required. Unique identifier for this result, 1-64 bytes
+ *   'video_url'              => '',  //  string                - Required. A valid URL for the embedded video player or video file
+ *   'mime_type'              => '',  //  string                - Required. Mime type of the content of video url, “text/html” or “video/mp4”
+ *   'thumb_url'              => '',  //  string                - Required. URL of the thumbnail (jpeg only) for the video
+ *   'title'                  => '',  //  string                - Required. Title for the result
+ *   'caption'                => '',  //  string                - (Optional). Caption of the video to be sent, 0-200 characters
+ *   'parse_mode'             => '',  //  string                - (Optional). Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in the media caption.
+ *   'caption_entities'       => '',  //  array                 - (Optional). List of special entities that appear in the caption, which can be specified instead of parse_mode
+ *   'video_width'            => '',  //  int                   - (Optional). Video width
+ *   'video_height'           => '',  //  int                   - (Optional). Video height
+ *   'video_duration'         => '',  //  int                   - (Optional). Video duration in seconds
+ *   'description'            => '',  //  string                - (Optional). Short description of the result
+ *   'reply_markup'           => '',  //  InlineKeyboardMarkup  - (Optional). Inline keyboard attached to the message
+ *   'input_message_content'  => '',  //  InputMessageContent   - (Optional). Content of the message to be sent instead of the photo
+ * ]
  * </code>
  *
  * @link https://core.telegram.org/bots/api#inlinequeryresultvideo

--- a/src/Objects/InlineQuery/InlineQueryResultVoice.php
+++ b/src/Objects/InlineQuery/InlineQueryResultVoice.php
@@ -5,17 +5,23 @@ namespace Telegram\Bot\Objects\InlineQuery;
 /**
  * Class InlineQueryResultVoice.
  *
+ * Represents a link to a voice recording in an .OGG container encoded with OPUS.
+ * By default, this voice recording will be sent by the user. Alternatively, you can
+ * use input_message_content to send a message with the specified content instead of the
+ * voice message.
+ *
  * <code>
- * $params = [
- *   'id'                         => '',
- *   'voice_url'                  => '',
- *   'title'                      => '',
- *   'caption'                    => '',
- *   'parse_mode'               => '',
- *   'voice_duration'             => '',
- *   'reply_markup'               => '',
- *   'input_message_content'      => '',
- * ];
+ * [
+ *   'id'                      => '',  //  string                - Required. Unique identifier for this result, 1-64 bytes
+ *   'voice_url'               => '',  //  string                - Required. A valid URL for the voice recording
+ *   'title'                   => '',  //  string                - Required. Recording title
+ *   'caption'                 => '',  //  string                - (Optional). Caption, 0-200 characters
+ *   'parse_mode'              => '',  //  string                - (Optional). Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in the media caption.
+ *   'caption_entities'       => '',   //  array                 - (Optional). List of special entities that appear in the caption, which can be specified instead of parse_mode
+ *   'voice_duration'          => '',  //  int                   - (Optional). Recording duration in seconds
+ *   'reply_markup'            => '',  //  InlineKeyboardMarkup  - (Optional). Inline keyboard attached to the message
+ *   'input_message_content'   => '',  //  InputMessageContent   - (Optional). Content of the message to be sent instead of the photo
+ * ]
  * </code>
  *
  * @link https://core.telegram.org/bots/api#inlinequeryresultvoice

--- a/src/Objects/InputContent/InputContactMessageContent.php
+++ b/src/Objects/InputContent/InputContactMessageContent.php
@@ -7,14 +7,18 @@ use Telegram\Bot\Objects\InlineQuery\InlineBaseObject;
 /**
  * Class InputContactMessageContent.
  *
+ * Represents the content of a contact message to be sent as the result of an inline query.
+ *
  * <code>
- * $params = [
- *   'phone_number'     => '',
- *   'first_name'       => '',
- *   'last_name'        => '',
- *   'vcard'            => '',
- * ];
+ * [
+ *   'phone_number'  => '',  //  string  - Required. Contact's phone number
+ *   'first_name'    => '',  //  string  - Required. Contact's first name
+ *   'last_name'     => '',  //  string  - (Optional). Contact's last name
+ *   'vcard'         => '',  //  string  - (Optional). Additional data about the contact in the form of a vCard, 0-2048 bytes
+ * ]
  * </code>
+ *
+ * @link https://core.telegram.org/bots/api#inputcontactmessagecontent
  *
  * @method $this setPhoneNumber(string) Contact's phone number
  * @method $this setFirstName(string)   Contact's first name

--- a/src/Objects/InputContent/InputLocationMessageContent.php
+++ b/src/Objects/InputContent/InputLocationMessageContent.php
@@ -7,12 +7,19 @@ use Telegram\Bot\Objects\InlineQuery\InlineBaseObject;
 /**
  * Class InputLocationMessageContent.
  *
+ * Represents the content of a location message to be sent as the result of an inline query.
+ *
  * <code>
- * $params = [
- *   'latitude'     => '',
- *   'longitude'    => '',
- *   'live_period'  => '',
- * ];
+ * [
+ *   'latitude'               => '',  //  float  - Required. Latitude of the location in degrees
+ *   'longitude'              => '',  //  float  - Required. Longitude of the location in degrees
+ *   'horizontal_accuracy'    => '',  //  float  - (Optional). The radius of uncertainty for the location, measured in meters; 0-1500
+ *   'live_period'            => '',  //  int    - (Optional). Period in seconds for which the location can be updated, should be between 60 and 86400.
+ *   'heading'                => '',  //  int    - (Optional). For live locations, a direction in which the user is moving, in degrees. Must be between 1 and 360 if specified.
+ *   'proximity_alert_radius' => '',  //  int    - (Optional). For live locations, a maximum distance for proximity alerts about approaching another chat member, in meters. Must be between 1 and 100000 if specified.
+ * ]
+ *
+ * @link https://core.telegram.org/bots/api#inputlocationmessagecontent
  *
  * @method $this setLatitude(float)    Latitude of the location in degrees
  * @method $this setLongitude(float)   Longitude of the location in degrees

--- a/src/Objects/InputContent/InputTextMessageContent.php
+++ b/src/Objects/InputContent/InputTextMessageContent.php
@@ -7,13 +7,18 @@ use Telegram\Bot\Objects\InlineQuery\InlineBaseObject;
 /**
  * Class InputTextMessageContent.
  *
+ * Represents the content of a text message to be sent as the result of an inline query.
+ *
  * <code>
- * $params = [
- *   'message_text'             => '',
- *   'parse_mode'               => '',
- *   'disable_web_page_preview' => '',
- * ];
+ * [
+ *   'message_text'              => '',  //  string  - Required. Text of the message to be sent, 1-4096 characters.
+ *   'parse_mode'                => '',  //  string  - (Optional). Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.
+ *   'entities'                  => '',  //  array   - (Optional). List of special entities that appear in the caption, which can be specified instead of parse_mode
+ *   'disable_web_page_preview'  => '',  //  bool    - (Optional). Disables link previews for links in the sent message
+ * ]
  * </code>
+ *
+ * @link https://core.telegram.org/bots/api#inputtextmessagecontent
  *
  * @method $this setMessageText(string)           Text of the message to be sent, 1-4096 characters.
  * @method $this setParseMode(string)             (Optional). Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.

--- a/src/Objects/InputContent/InputVenueMessageContent.php
+++ b/src/Objects/InputContent/InputVenueMessageContent.php
@@ -7,16 +7,22 @@ use Telegram\Bot\Objects\InlineQuery\InlineBaseObject;
 /**
  * Class InputVenueMessageContent.
  *
+ * Represents the content of a venue message to be sent as the result of an inline query.
+ *
  * <code>
- * $params = [
- *   'latitude'         => '',
- *   'longitude'        => '',
- *   'title'            => '',
- *   'address'          => '',
- *   'foursquare_id'    => '',
- *   'foursquare_type'  => '',
- * ];
+ * [
+ *   'latitude'          => '',  //  float   - Required. Latitude of the location in degrees
+ *   'longitude'         => '',  //  float   - Required. Longitude of the location in degrees
+ *   'title'             => '',  //  string  - Required. Name of the venue
+ *   'address'           => '',  //  string  - Required. Address of the venue
+ *   'foursquare_id'     => '',  //  string  - (Optional). Foursquare identifier of the venue, if known
+ *   'foursquare_type'   => '',  //  string  - (Optional). Foursquare type of the venue, if known. (For example, “arts_entertainment/default”, “arts_entertainment/aquarium” or “food/icecream”.)
+ *   'google_place_id'   => '',  //  string  - (Optional). Google Places identifier of the venue
+ *   'google_place_type' => '',  //  string  - (Optional). Google Places type of the venue.
+ * ]
  * </code>
+ *
+ * @link https://core.telegram.org/bots/api#inputvenuemessagecontent
  *
  * @method $this setLatitude(float)             Latitude of the location in degrees
  * @method $this setLongitude(float)            Longitude of the location in degrees

--- a/src/Objects/InputMedia/InputMedia.php
+++ b/src/Objects/InputMedia/InputMedia.php
@@ -6,7 +6,8 @@ use Telegram\Bot\Objects\BaseObject;
 
 /**
  * Class InputMedia.
- *  This object represents the content of a media message to be sent.
+ *
+ * This object represents the content of a media message to be sent.
  */
 class InputMedia extends BaseObject
 {

--- a/src/Objects/InputMedia/InputMediaAnimation.php
+++ b/src/Objects/InputMedia/InputMediaAnimation.php
@@ -8,6 +8,8 @@ use Telegram\Bot\FileUpload\InputFile;
  * Class InputMediaAnimation.
  * Represents an animation file (GIF or H.264/MPEG-4 AVC video without sound) to be sent.
  *
+ * @link https://core.telegram.org/bots/api#inputmediaanimation
+ *
  * @property string                $type         Type of the result, must be animation.
  * @property string                $media        File to send. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an HTTP URL for Telegram to get a file from the Internet, or pass “attach://<file_attach_name>” to upload a new one using multipart/form-data under <file_attach_name> name.
  * @property InputFile|string|null $thumb        (Optional). Thumbnail of the file sent. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail‘s width and height should not exceed 90. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can’t be reused and can be only uploaded as a new file, so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using multipart/form-data under <file_attach_name>

--- a/src/Objects/InputMedia/InputMediaAudio.php
+++ b/src/Objects/InputMedia/InputMediaAudio.php
@@ -8,6 +8,8 @@ use Telegram\Bot\FileUpload\InputFile;
  * Class InputMediaAudio.
  * Represents an audio file to be treated as music to be sent.
  *
+ * @link https://core.telegram.org/bots/api#inputmediaaudio
+ *
  * @property string                $type        Type of the result, must be audio.
  * @property string                $media       File to send. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an HTTP URL for Telegram to get a file from the Internet, or pass “attach://<file_attach_name>” to upload a new one using multipart/form-data under <file_attach_name> name.
  * @property InputFile|string|null $thumb       (Optional). Thumbnail of the file sent. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail‘s width and height should not exceed 90. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can’t be reused and can be only uploaded as a new file, so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using multipart/form-data under <file_attach_name>

--- a/src/Objects/InputMedia/InputMediaDocument.php
+++ b/src/Objects/InputMedia/InputMediaDocument.php
@@ -6,7 +6,10 @@ use Telegram\Bot\FileUpload\InputFile;
 
 /**
  * Class InputMediaDocument.
+ *
  * Represents a general file to be sent.
+ *
+ * @link https://core.telegram.org/bots/api#inputmediadocument
  *
  * @property string                $type           Type of the result, must be document.
  * @property string                $media          File to send. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an HTTP URL for Telegram to get a file from the Internet, or pass “attach://<file_attach_name>” to upload a new one using multipart/form-data under <file_attach_name> name.

--- a/src/Objects/InputMedia/InputMediaPhoto.php
+++ b/src/Objects/InputMedia/InputMediaPhoto.php
@@ -5,6 +5,10 @@ namespace Telegram\Bot\Objects\InputMedia;
 /**
  * Class InputMediaPhoto.
  *
+ * Represents a photo to be sent.
+ *
+ * @link https://core.telegram.org/bots/api#inputmediaphoto
+ *
  * @property string      $type             Type of the result, must be photo.
  * @property string      $media            File to send. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an HTTP URL for Telegram to get a file from the Internet, or pass “attach://<file_attach_name>” to upload a new one using multipart/form-data under <file_attach_name> name.
  * @property string|null $caption          (Optional). Caption of the photo to be sent, 0-200 characters

--- a/src/Objects/InputMedia/InputMediaVideo.php
+++ b/src/Objects/InputMedia/InputMediaVideo.php
@@ -7,6 +7,10 @@ use Telegram\Bot\FileUpload\InputFile;
 /**
  * Class InputMediaVideo.
  *
+ * Represents a video to be sent.
+ *
+ * @link https://core.telegram.org/bots/api#inputmediavideo
+ *
  * @property string                $type                 Type of the result, must be video.
  * @property string                $media                File to send. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an HTTP URL for Telegram to get a file from the Internet, or pass “attach://<file_attach_name>” to upload a new one using multipart/form-data under <file_attach_name> name.
  * @property InputFile|string|null $thumb                (Optional). Thumbnail of the file sent. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail‘s width and height should not exceed 90. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can’t be reused and can be only uploaded as a new file, so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using multipart/form-data under <file_attach_name>

--- a/src/Objects/Location.php
+++ b/src/Objects/Location.php
@@ -5,9 +5,14 @@ namespace Telegram\Bot\Objects;
 /**
  * Class Location.
  *
+ * @link https://core.telegram.org/bots/api#location
  *
- * @property float $longitude  Longitude as defined by sender.
- * @property float $latitude   Latitude as defined by sender.
+ * @property float      $longitude              Longitude as defined by sender.
+ * @property float      $latitude               Latitude as defined by sender.
+ * @property float|null $horizontalAccuracy     (Optional). The radius of uncertainty for the location, measured in meters; 0-1500
+ * @property int|null   $livePeriod             (Optional). Time relative to the message sending date, during which the location can be updated, in seconds. For active live locations only.
+ * @property int|null   $heading                (Optional). The direction in which user is moving, in degrees; 1-360. For active live locations only.
+ * @property int|null   $proximityAlertRadius   (Optional). Maximum distance for proximity alerts about approaching another chat member, in meters. For sent live locations only.
  */
 class Location extends BaseObject
 {

--- a/src/Objects/LoginUrl.php
+++ b/src/Objects/LoginUrl.php
@@ -5,6 +5,8 @@ namespace Telegram\Bot\Objects;
 /**
  * Class LoginUrl.
  *
+ * @link https://core.telegram.org/bots/api#loginurl
+ *
  * @property string      $url                    An HTTP URL to be opened with user authorization data added to the query string when the button is pressed. If the user refuses to provide authorization data, the original URL without information about the user will be opened. The data added is the same as described in Receiving authorization data
  * @property string|null $forwardText            (Optional). New text of the button in forwarded messages.
  * @property string|null $botUsername            (Optional). Username of a bot, which will be used for user authorization. See Setting up a bot for more details. If not specified, the current bot's username will be assumed. The url's domain must be the same as the domain linked with the bot. See Linking your domain to the bot for more details.

--- a/src/Objects/MaskPosition.php
+++ b/src/Objects/MaskPosition.php
@@ -5,6 +5,7 @@ namespace Telegram\Bot\Objects;
 /**
  * Class MaskPosition.
  *
+ * @link https://core.telegram.org/bots/api#maskposition
  *
  * @property string $point       The part of the face relative to which the mask should be placed. One of “forehead”, “eyes”, “mouth”, or “chin”.
  * @property float  $xShift      Shift by X-axis measured in widths of the mask scaled to the face size, from left to right. For example, choosing -1.0 will place mask just to the left of the default mask position.

--- a/src/Objects/Message.php
+++ b/src/Objects/Message.php
@@ -95,8 +95,12 @@ class Message extends BaseObject
             'pinned_message'     => self::class,
             'invoice'            => Invoice::class,
             'successful_payment' => SuccessfulPayment::class,
-            'passport'           => PassportData::class,
+            'passport_data'      => PassportData::class,
             'sender_chat'        => Chat::class,
+            'proximity_alert_triggered'       => ProximityAlertTriggered::class,
+            'voice_chat_started'              => VoiceChatStarted::class,
+            'voice_chat_ended'                => VoiceChatEnded::class,
+            'voice_chat_participants_invited' => VoiceChatParticipantsInvited::class,
         ];
     }
 
@@ -121,6 +125,17 @@ class Message extends BaseObject
      *
      * @return string|null
      */
+    public function objectType(): ?string
+    {
+        return $this->detectType();
+    }
+
+    /**
+     * Detect type based on properties.
+     * @deprecated Will be removed in v4.0, please use {@see \Telegram\Bot\Objects\Message::objectType} instead.
+     *
+     * @return string|null
+     */
     public function detectType()
     {
         $types = [
@@ -128,7 +143,6 @@ class Message extends BaseObject
             'audio',
             'animation',
             'dice',
-            'invoice',
             'document',
             'game',
             'photo',
@@ -152,11 +166,16 @@ class Message extends BaseObject
             'migrate_to_chat_id',
             'migrate_from_chat_id',
             'pinned_message',
+            'invoice',
+            'successful_payment',
+            'passport_data',
+            'proximity_alert_triggered',
+            'voice_chat_started',
+            'voice_chat_ended',
+            'voice_chat_participants_invited',
         ];
 
-        return $this->keys()
-            ->intersect($types)
-            ->pop();
+        return $this->findType($types);
     }
 
     /**

--- a/src/Objects/MessageAutoDeleteTimerChanged.php
+++ b/src/Objects/MessageAutoDeleteTimerChanged.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Telegram\Bot\Objects;
+
+/**
+ * Class MessageAutoDeleteTimerChanged.
+ *
+ * @link https://core.telegram.org/bots/api#messageautodeletetimerchanged
+ *
+ * @property int $message_auto_delete_time  New auto-delete time for messages in the chat; in seconds
+ */
+class MessageAutoDeleteTimerChanged extends BaseObject
+{
+    public function relations()
+    {
+        return [];
+    }
+}

--- a/src/Objects/MessageEntity.php
+++ b/src/Objects/MessageEntity.php
@@ -5,11 +5,14 @@ namespace Telegram\Bot\Objects;
 /**
  * Class MessageEntity.
  *
- * @property string      $type   Type of the entity. Can be “mention” (@username), “hashtag” (#hashtag), “cashtag” ($USD), “bot_command” (/start@jobs_bot), “url” (https://telegram.org), “email” (do-not-reply@telegram.org), “phone_number” (+1-212-555-0123), “bold” (bold text), “italic” (italic text), “underline” (underlined text), “strikethrough” (strikethrough text), “code” (monowidth string), “pre” (monowidth block), “text_link” (for clickable text URLs), “text_mention” (for users without usernames)
- * @property int         $offset Offset in UTF-16 code units to the start of the entity
- * @property int         $length Length of the entity in UTF-16 code units
- * @property string|null $url    (Optional). For "text_link" only, url that will be opened after user taps on the text.
- * @property User|null   $user   (Optional). For “text_mention” only, the mentioned user.
+ * @link https://core.telegram.org/bots/api#messageentity
+ *
+ * @property string      $type      Type of the entity. Can be “mention” (@username), “hashtag” (#hashtag), “cashtag” ($USD), “bot_command” (/start@jobs_bot), “url” (https://telegram.org), “email” (do-not-reply@telegram.org), “phone_number” (+1-212-555-0123), “bold” (bold text), “italic” (italic text), “underline” (underlined text), “strikethrough” (strikethrough text), “code” (monowidth string), “pre” (monowidth block), “text_link” (for clickable text URLs), “text_mention” (for users without usernames)
+ * @property int         $offset    Offset in UTF-16 code units to the start of the entity
+ * @property int         $length    Length of the entity in UTF-16 code units
+ * @property string|null $url       (Optional). For "text_link" only, url that will be opened after user taps on the text.
+ * @property User|null   $user      (Optional). For “text_mention” only, the mentioned user.
+ * @property string|null $language  (Optional). For “pre” only, the programming language of the entity text.
  */
 class MessageEntity extends BaseObject
 {

--- a/src/Objects/Passport/Credentials.php
+++ b/src/Objects/Passport/Credentials.php
@@ -5,10 +5,10 @@ namespace Telegram\Bot\Objects\Passport;
 use Telegram\Bot\Objects\BaseObject;
 
 /**
+ * @link https://core.telegram.org/bots/api#credentials
+ *
  * @property SecureData $secureData   Credentials for encrypted data
  * @property string     $nonce        Bot-specified nonce
- *
- * @link https://core.telegram.org/bots/api#credentials
  */
 class Credentials extends BaseObject
 {

--- a/src/Objects/Passport/DataCredentials.php
+++ b/src/Objects/Passport/DataCredentials.php
@@ -5,10 +5,10 @@ namespace Telegram\Bot\Objects\Passport;
 use Telegram\Bot\Objects\BaseObject;
 
 /**
+ * @link https://core.telegram.org/bots/api#datacredentials
+ *
  * @property string $dataHash     Checksum of encrypted data
  * @property string $secret       Secret of encrypted data
- *
- * @link https://core.telegram.org/bots/api#datacredentials
  */
 class DataCredentials extends BaseObject
 {

--- a/src/Objects/Passport/EncryptedPassportElement.php
+++ b/src/Objects/Passport/EncryptedPassportElement.php
@@ -5,6 +5,8 @@ namespace Telegram\Bot\Objects\Passport;
 use Telegram\Bot\Objects\BaseObject;
 
 /**
+ * @link https://core.telegram.org/bots/api#encryptedpassportelement
+ *
  * @property string              $type           Element type. One of “personal_details”, “passport”, “driver_license”, “identity_card”, “internal_passport”, “address”, “utility_bill”, “bank_statement”, “rental_agreement”, “passport_registration”, “temporary_registration”, “phone_number”, “email”.
  * @property string|null         $data           (Optional). Base64-encoded encrypted Telegram Passport element data provided by the user, available for “personal_details”, “passport”, “driver_license”, “identity_card”, “internal_passport” and “address” types. Can be decrypted and verified using the accompanying EncryptedCredentials.
  * @property string|null         $phoneNumber    (Optional). User's verified phone number, available only for “phone_number” type
@@ -15,8 +17,6 @@ use Telegram\Bot\Objects\BaseObject;
  * @property PassportFile|null   $selfie         (Optional). Encrypted file with the selfie of the user holding a document, provided by the user; available for “passport”, “driver_license”, “identity_card” and “internal_passport”. The file can be decrypted and verified using the accompanying EncryptedCredentials.
  * @property PassportFile[]|null $translation    (Optional). Array of encrypted files with translated versions of documents provided by the user. Available if requested for “passport”, “driver_license”, “identity_card”, “internal_passport”, “utility_bill”, “bank_statement”, “rental_agreement”, “passport_registration” and “temporary_registration” types. Files can be decrypted and verified using the accompanying EncryptedCredentials.
  * @property string|null         $hash           (Optional). Base64-encoded element hash for using in PassportElementErrorUnspecified
- *
- * @link https://core.telegram.org/bots/api#encryptedpassportelement
  */
 class EncryptedPassportElement extends BaseObject
 {

--- a/src/Objects/Passport/FileCredentials.php
+++ b/src/Objects/Passport/FileCredentials.php
@@ -5,10 +5,10 @@ namespace Telegram\Bot\Objects\Passport;
 use Telegram\Bot\Objects\BaseObject;
 
 /**
+ * @link https://core.telegram.org/bots/api#filecredentials
+ *
  * @property string  $fileHash     Checksum of encrypted file
  * @property string  $secret       Secret of encrypted file
- *
- * @link https://core.telegram.org/bots/api#filecredentials
  */
 class FileCredentials extends BaseObject
 {

--- a/src/Objects/Passport/IdDocumentData.php
+++ b/src/Objects/Passport/IdDocumentData.php
@@ -5,10 +5,10 @@ namespace Telegram\Bot\Objects\Passport;
 use Telegram\Bot\Objects\BaseObject;
 
 /**
+ * @link https://core.telegram.org/bots/api#iddocumentdata
+ *
  * @property string $documentNo    Document number
  * @property string|null $expiryDate (Optional). Date of expiry, in DD.MM.YYYY format
- *
- * @link https://core.telegram.org/bots/api#iddocumentdata
  */
 class IdDocumentData extends BaseObject
 {

--- a/src/Objects/Passport/PassportFile.php
+++ b/src/Objects/Passport/PassportFile.php
@@ -5,12 +5,12 @@ namespace Telegram\Bot\Objects\Passport;
 use Telegram\Bot\Objects\BaseObject;
 
 /**
+ * @link https://core.telegram.org/bots/api#passportfile
+ *
  * @property string $fileId              Unique identifier for this file
  * @property string $fileUniqueId        Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
  * @property int    $fileSize            File size
  * @property int    $fileDate            Unix time when the file was uploaded
- *
- * @link https://core.telegram.org/bots/api#passportfile
  */
 class PassportFile extends BaseObject
 {

--- a/src/Objects/Passport/PassportScope.php
+++ b/src/Objects/Passport/PassportScope.php
@@ -5,10 +5,10 @@ namespace Telegram\Bot\Objects\Passport;
 use Telegram\Bot\Objects\BaseObject;
 
 /**
+ * @link https://core.telegram.org/bots/api#passportscope
+ *
  * @property PassportScopeElement[]  $data            List of requested elements, each type may be used only once in the entire array of PassportScopeElement objects
  * @property int                     $v               Scope version, must be 1
- *
- * @link https://core.telegram.org/bots/api#passportscope
  */
 class PassportScope extends BaseObject
 {

--- a/src/Objects/Passport/PassportScopeElementOne.php
+++ b/src/Objects/Passport/PassportScopeElementOne.php
@@ -3,12 +3,12 @@
 namespace Telegram\Bot\Objects\Passport;
 
 /**
+ * @link https://core.telegram.org/bots/api#passportscopeelementone
+ *
  * @property string    $type            Element type. One of “personal_details”, “passport”, “driver_license”, “identity_card”, “internal_passport”, “address”, “utility_bill”, “bank_statement”, “rental_agreement”, “passport_registration”, “temporary_registration”, “phone_number”, “email”
  * @property bool|null $selfie          (Optional). Use this parameter if you want to request a selfie with the document as well. Available for “passport”, “driver_license”, “identity_card” and “internal_passport”
  * @property bool|null $translation     (Optional). Use this parameter if you want to request a translation of the document as well. Available for “passport”, “driver_license”, “identity_card”, “internal_passport”, “utility_bill”, “bank_statement”, “rental_agreement”, “passport_registration” and “temporary_registration”. Note: We suggest to only request translations after you have received a valid document that requires one.
  * @property bool|null $nativeNames     (Optional). Use this parameter to request the first, last and middle name of the user in the language of the user's country of residence. Available for “personal_details”
- *
- * @link https://core.telegram.org/bots/api#passportscopeelementone
  */
 class PassportScopeElementOne extends PassportScopeElement
 {

--- a/src/Objects/Passport/SecureData.php
+++ b/src/Objects/Passport/SecureData.php
@@ -5,6 +5,8 @@ namespace Telegram\Bot\Objects\Passport;
 use Telegram\Bot\Objects\BaseObject;
 
 /**
+ * @link https://core.telegram.org/bots/api#securedata
+ *
  * @property SecureValue|null $personalDetails            (Optional). Credentials for encrypted personal details
  * @property SecureValue|null $passport                   (Optional). Credentials for encrypted passport
  * @property SecureValue|null $internalPassport           (Optional). Credentials for encrypted internal passport
@@ -16,8 +18,6 @@ use Telegram\Bot\Objects\BaseObject;
  * @property SecureValue|null $rentalAgreement            (Optional). Credentials for encrypted rental agreement
  * @property SecureValue|null $passportRegistration       (Optional). Credentials for encrypted registration from internal passport
  * @property SecureValue|null $temporaryRegistration      (Optional). Credentials for encrypted temporary registration
- *
- * @link https://core.telegram.org/bots/api#securedata
  */
 class SecureData extends BaseObject
 {

--- a/src/Objects/Passport/SecureValue.php
+++ b/src/Objects/Passport/SecureValue.php
@@ -5,14 +5,14 @@ namespace Telegram\Bot\Objects\Passport;
 use Telegram\Bot\Objects\BaseObject;
 
 /**
+ * @link https://core.telegram.org/bots/api#securevalue
+ *
  * @property DataCredentials|null   $data          (Optional). Credentials for encrypted Telegram Passport data. Available for “personal_details”, “passport”, “driver_license”, “identity_card”, “internal_passport” and “address” types.
  * @property FileCredentials|null   $frontSide     (Optional). Credentials for an encrypted document's front side. Available for “passport”, “driver_license”, “identity_card” and “internal_passport”.
  * @property FileCredentials|null   $reverseSide   (Optional). Credentials for an encrypted document's reverse side. Available for “driver_license” and “identity_card”.
  * @property FileCredentials|null   $selfie        (Optional). Credentials for an encrypted selfie of the user with a document. Available for “passport”, “driver_license”, “identity_card” and “internal_passport”.
  * @property FileCredentials[]|null $translation   (Optional). Credentials for an encrypted translation of the document. Available for “passport”, “driver_license”, “identity_card”, “internal_passport”, “utility_bill”, “bank_statement”, “rental_agreement”, “passport_registration” and “temporary_registration”.
  * @property FileCredentials[]|null $files         (Optional). Credentials for encrypted files. Available for “utility_bill”, “bank_statement”, “rental_agreement”, “passport_registration” and “temporary_registration” types.
- *
- * @link https://core.telegram.org/bots/api#securevalue
  */
 class SecureValue extends BaseObject
 {

--- a/src/Objects/Payments/Invoice.php
+++ b/src/Objects/Payments/Invoice.php
@@ -5,13 +5,13 @@ namespace Telegram\Bot\Objects\Payments;
 use Telegram\Bot\Objects\BaseObject;
 
 /**
+ * @link https://core.telegram.org/bots/api#invoice
+ *
  * @property string $title                    Product name
  * @property string $description              Product description
  * @property string $startParameter           Unique bot deep-linking parameter that can be used to generate this invoice
  * @property string $currency                 Three-letter ISO 4217 currency code
  * @property int    $totalAmount              Total price in the smallest units of the currency (integer, not float/double)
- *
- * @link https://core.telegram.org/bots/api#invoice
  */
 class Invoice extends BaseObject
 {

--- a/src/Objects/Payments/LabeledPrice.php
+++ b/src/Objects/Payments/LabeledPrice.php
@@ -5,10 +5,10 @@ namespace Telegram\Bot\Objects\Payments;
 use Telegram\Bot\Objects\BaseObject;
 
 /**
+ * @link https://core.telegram.org/bots/api#labeledprice
+ *
  * @property string $label               Portion label
  * @property int    $amount              Price of the product in the smallest units of the currency (integer, not float/double).
- *
- * @link https://core.telegram.org/bots/api#labeledprice
  */
 class LabeledPrice extends BaseObject
 {

--- a/src/Objects/Payments/OrderInfo.php
+++ b/src/Objects/Payments/OrderInfo.php
@@ -5,12 +5,12 @@ namespace Telegram\Bot\Objects\Payments;
 use Telegram\Bot\Objects\BaseObject;
 
 /**
+ * @link https://core.telegram.org/bots/api#orderinfo
+ *
  * @property string|null          $name            (Optional). User name
  * @property string|null          $phoneNumber     (Optional). User's phone number
  * @property string|null          $email           (Optional). User email
  * @property ShippingAddress|null $shippingAddress (Optional). User shipping address
- *
- * @link https://core.telegram.org/bots/api#orderinfo
  */
 class OrderInfo extends BaseObject
 {

--- a/src/Objects/Payments/PreCheckoutQuery.php
+++ b/src/Objects/Payments/PreCheckoutQuery.php
@@ -6,6 +6,10 @@ use Telegram\Bot\Objects\BaseObject;
 use Telegram\Bot\Objects\User;
 
 /**
+ * Class PreCheckoutQuery
+ *
+ * @link https://core.telegram.org/bots/api#precheckoutquery
+ *
  * @property string         $id                     Unique query identifier
  * @property User           $from                   User who sent the query.
  * @property string         $currency               Three-letter ISO 4217 currency code
@@ -13,8 +17,6 @@ use Telegram\Bot\Objects\User;
  * @property string         $invoicePayload         Bot specified invoice payload
  * @property string|null    $shippingOptionId       (Optional). Identifier of the shipping option chosen by the user
  * @property OrderInfo|null $orderInfo              (Optional). Order info provided by the user
- *
- * @link https://core.telegram.org/bots/api#precheckoutquery
  */
 class PreCheckoutQuery extends BaseObject
 {
@@ -27,5 +29,10 @@ class PreCheckoutQuery extends BaseObject
             'from'       => User::class,
             'order_info' => OrderInfo::class,
         ];
+    }
+
+    public function objectType(): ?string
+    {
+        return $this->findType(['shipping_option_id', 'order_info']);
     }
 }

--- a/src/Objects/Payments/ShippingAddress.php
+++ b/src/Objects/Payments/ShippingAddress.php
@@ -5,14 +5,14 @@ namespace Telegram\Bot\Objects\Payments;
 use Telegram\Bot\Objects\BaseObject;
 
 /**
+ * @link https://core.telegram.org/bots/api#shippingaddress
+ *
  * @property string $countryCode                   ISO 3166-1 alpha-2 country code
  * @property string $state                         State, if applicable
  * @property string $city                          City
  * @property string $streetLine1                   First line for the address.
  * @property string $streetLine2                   Second line for the address.
  * @property string $postCode                      Address post code
- *
- * @link https://core.telegram.org/bots/api#shippingaddress
  */
 class ShippingAddress extends BaseObject
 {

--- a/src/Objects/Payments/ShippingOption.php
+++ b/src/Objects/Payments/ShippingOption.php
@@ -5,11 +5,11 @@ namespace Telegram\Bot\Objects\Payments;
 use Telegram\Bot\Objects\BaseObject;
 
 /**
+ * @link https://core.telegram.org/bots/api#shippingoption
+ *
  * @property string         $id        Shipping option identifier.
  * @property string         $title     Option title.
  * @property LabeledPrice[] $prices    List of price portions.
- *
- * @link https://core.telegram.org/bots/api#shippingoption
  */
 class ShippingOption extends BaseObject
 {

--- a/src/Objects/Payments/ShippingQuery.php
+++ b/src/Objects/Payments/ShippingQuery.php
@@ -6,12 +6,14 @@ use Telegram\Bot\Objects\BaseObject;
 use Telegram\Bot\Objects\User;
 
 /**
+ * Class ShippingQuery
+ *
+ * @link https://core.telegram.org/bots/api#shippingquery
+ *
  * @property string          $id                   Unique query identifier
  * @property User            $from                 User who sent the query.
  * @property string          $invoicePayload       Bot specified invoice payload
  * @property ShippingAddress $shippingAddress      User specified shipping address
- *
- * @link https://core.telegram.org/bots/api#shippingquery
  */
 class ShippingQuery extends BaseObject
 {

--- a/src/Objects/Payments/SuccessfulPayment.php
+++ b/src/Objects/Payments/SuccessfulPayment.php
@@ -5,6 +5,8 @@ namespace Telegram\Bot\Objects\Payments;
 use Telegram\Bot\Objects\BaseObject;
 
 /**
+ * @link https://core.telegram.org/bots/api#successfulpayment
+ *
  * @property string         $currency                          Three-letter ISO 4217 currency code
  * @property int            $totalAmount                       Total price in the smallest units of the currency (integer, not float/double)
  * @property string         $invoicePayload                    Bot specified invoice payload
@@ -12,8 +14,6 @@ use Telegram\Bot\Objects\BaseObject;
  * @property OrderInfo|null $orderInfo                         (Optional). Order info provided by the user
  * @property string         $telegramPaymentChargeId           Telegram payment identifier.
  * @property string         $providerPaymentChargeId           Provider payment identifier.
- *
- * @link https://core.telegram.org/bots/api#successfulpayment
  */
 class SuccessfulPayment extends BaseObject
 {

--- a/src/Objects/PhotoSize.php
+++ b/src/Objects/PhotoSize.php
@@ -5,6 +5,7 @@ namespace Telegram\Bot\Objects;
 /**
  * Class PhotoSize.
  *
+ * @link https://core.telegram.org/bots/api#photosize
  *
  * @property string   $fileId         Unique identifier for this file.
  * @property string   $fileUniqueId   Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.

--- a/src/Objects/Poll.php
+++ b/src/Objects/Poll.php
@@ -5,16 +5,21 @@ namespace Telegram\Bot\Objects;
 /**
  * Class Poll.
  *
+ * @link https://core.telegram.org/bots/api#poll
  *
- * @property string       $id                     Unique poll identifier
- * @property string       $question               Poll question, 1-255 characters.
- * @property PollOption[] $options                List of poll options
- * @property int          $totalVoterCount        Total number of users that voted in the poll
- * @property bool         $isClosed               True, if the poll is closed.
- * @property bool         $isAnonymous            True, if the poll is anonymous.
- * @property string       $type                   Poll type, currently can be “regular” or “quiz”
- * @property bool         $allowMultipleAnswers   True, if the poll allows multiple answers.
- * @property int|null     $correctOptionId        (Optional). 0-based identifier of the correct answer option. Available only for polls in the quiz mode, which are closed, or was sent (not forwarded) by the bot or to the private chat with the bot.
+ * @property string                 $id                     Unique poll identifier
+ * @property string                 $question               Poll question, 1-255 characters.
+ * @property PollOption[]           $options                List of poll options
+ * @property int                    $totalVoterCount        Total number of users that voted in the poll
+ * @property bool                   $isClosed               True, if the poll is closed.
+ * @property bool                   $isAnonymous            True, if the poll is anonymous.
+ * @property string                 $type                   Poll type, currently can be “regular” or “quiz”
+ * @property bool                   $allowMultipleAnswers   True, if the poll allows multiple answers.
+ * @property int|null               $correctOptionId        (Optional). 0-based identifier of the correct answer option. Available only for polls in the quiz mode, which are closed, or was sent (not forwarded) by the bot or to the private chat with the bot.
+ * @property string|null            $explanation            (Optional). Text that is shown when a user chooses an incorrect answer or taps on the lamp icon in a quiz-style poll, 0-200 characters
+ * @property MessageEntity[]|null   $explanationEntities    (Optional). Special entities like usernames, URLs, bot commands, etc. that appear in the explanation
+ * @property int|null               $openPeriod             (Optional). Amount of time in seconds the poll will be active after creation
+ * @property int|null               $closeDate              (Optional). Point in time (Unix timestamp) when the poll will be automatically closed
  */
 class Poll extends BaseObject
 {

--- a/src/Objects/PollAnswer.php
+++ b/src/Objects/PollAnswer.php
@@ -5,10 +5,11 @@ namespace Telegram\Bot\Objects;
 /**
  * Class PollAnswer.
  *
+ * @link https://core.telegram.org/bots/api#pollanswer
  *
- * @property string       $poll_id      Unique poll identifier.
+ * @property string       $pollId       Unique poll identifier.
  * @property User         $user         The user, who changed the answer to the poll.
- * @property array        $option_ids   0-based identifiers of answer options, chosen by the user. May be empty if the user retracted their vote.
+ * @property array        $optionIds    Array of Integer. 0-based identifiers of answer options, chosen by the user. May be empty if the user retracted their vote.
  */
 class PollAnswer extends BaseObject
 {

--- a/src/Objects/PollOption.php
+++ b/src/Objects/PollOption.php
@@ -5,6 +5,7 @@ namespace Telegram\Bot\Objects;
 /**
  * Class PollOption.
  *
+ * @link https://core.telegram.org/bots/api#polloption
  *
  * @property string $text           Option text, 1-100 characters
  * @property int    $voterCount     Number of users that voted for this option

--- a/src/Objects/ProximityAlertTriggered.php
+++ b/src/Objects/ProximityAlertTriggered.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Telegram\Bot\Objects;
+
+/**
+ * Class ProximityAlertTriggered.
+ *
+ * @link https://core.telegram.org/bots/api#proximityalerttriggered
+ *
+ * @property User $traveler  User that triggered the alert
+ * @property User $watcher   User that set the alert
+ * @property int  $distance  The distance between the users
+ */
+class ProximityAlertTriggered extends BaseObject
+{
+    public function relations(): array
+    {
+        return [
+            'user' => User::class,
+        ];
+    }
+}

--- a/src/Objects/ResponseParameters.php
+++ b/src/Objects/ResponseParameters.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Telegram\Bot\Objects;
+
+/**
+ * Class ResponseParameters.
+ *
+ * Contains information about why a request was unsuccessful.
+ *
+ * @link https://core.telegram.org/bots/api#responseparameters
+ *
+ * @property int|null $migrateToChatId   (Optional). The group has been migrated to a supergroup with the specified identifier. This number may be greater than 32 bits and some programming languages may have difficulty/silent defects in interpreting it. But it is smaller than 52 bits, so a signed 64 bit integer or double-precision float type are safe for storing this identifier.
+ * @property int|null $retryAfter        (Optional). In case of exceeding flood control, the number of seconds left to wait before the request can be repeated
+ */
+class ResponseParameters extends BaseObject
+{
+    public function relations()
+    {
+        return [];
+    }
+}

--- a/src/Objects/Sticker.php
+++ b/src/Objects/Sticker.php
@@ -5,6 +5,7 @@ namespace Telegram\Bot\Objects;
 /**
  * Class Sticker.
  *
+ * @link https://core.telegram.org/bots/api#sticker
  *
  * @property string            $fileId              Unique identifier for this file.
  * @property string            $fileUniqueId        Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.

--- a/src/Objects/StickerSet.php
+++ b/src/Objects/StickerSet.php
@@ -5,6 +5,8 @@ namespace Telegram\Bot\Objects;
 /**
  * Class StickerSet.
  *
+ * @link https://core.telegram.org/bots/api#stickerset
+ *
  * @property string         $name               Sticker set name
  * @property string         $title              Sticker set title
  * @property bool           $isAnimated         True, if the sticker set contains animated stickers

--- a/src/Objects/Update.php
+++ b/src/Objects/Update.php
@@ -164,6 +164,17 @@ class Update extends BaseObject
     }
 
     /**
+     * Borrowed from {@see \Telegram\Bot\Objects\Update::getMessage()} from SDK v4.
+     * Get the message contained in the Update.
+     *
+     * @return Message|InlineQuery|ChosenInlineResult|CallbackQuery|ShippingQuery|PreCheckoutQuery|Poll|PollAnswer
+     */
+    public function getRelatedObject()
+    {
+        return $this->{$this->objectType()};
+    }
+
+    /**
      * Get chat object (if exists).
      *
      * @return Chat|Collection
@@ -176,6 +187,7 @@ class Update extends BaseObject
     }
 
     /**
+     * @deprecated This method will be removed in SDK v4
      * Is there a command entity in this update object.
      *
      * @return bool

--- a/src/Objects/Update.php
+++ b/src/Objects/Update.php
@@ -5,10 +5,14 @@ namespace Telegram\Bot\Objects;
 use Illuminate\Support\Collection;
 use Telegram\Bot\Objects\Payments\PreCheckoutQuery;
 use Telegram\Bot\Objects\Payments\ShippingQuery;
+use Telegram\Bot\Objects\Updates\ChatJoinRequest;
+use Telegram\Bot\Objects\Updates\ChatMemberUpdated;
+use Telegram\Bot\Objects\Updates\PollAnswer;
 
 /**
  * Class Update.
  *
+ * @link https://core.telegram.org/bots/api#update
  *
  * @property int                     $updateId               The update's unique identifier. Update identifiers start from a certain positive number and increase sequentially.
  * @property Message|null            $message                (Optional). New incoming message of any kind - text, photo, sticker, etc.
@@ -21,27 +25,36 @@ use Telegram\Bot\Objects\Payments\ShippingQuery;
  * @property ShippingQuery|null      $shippingQuery          (Optional). New incoming shipping query. Only for invoices with flexible price
  * @property PreCheckoutQuery|null   $preCheckoutQuery       (Optional). New incoming pre-checkout query. Contains full information about checkout
  * @property Poll|null               $poll                   (Optional). New poll state. Bots receive only updates about stopped polls and polls, which are sent by the bot
+ * @property PollAnswer|null         $pollAnswer             (Optional). A user changed their answer in a non-anonymous poll. Bots receive new votes only in polls that were sent by the bot itself.
+ * @property ChatMemberUpdated|null  $myChatMember           (Optional). The bot's chat member status was updated in a chat. For private chats, this update is received only when the bot is blocked or unblocked by the user.
+ * @property ChatMemberUpdated|null  $chatMember             (Optional). A chat member's status was updated in a chat. The bot must be an administrator in the chat and must explicitly specify “chat_member” in the list of allowed_updates to receive these updates.
+ * @property ChatJoinRequest|null    $chatJoinRequest        (Optional). A request to join the chat has been sent. The bot must have the can_invite_users administrator right in the chat to receive these updates.
  *
- * @link https://core.telegram.org/bots/api#update
  */
 class Update extends BaseObject
 {
+    protected ?string $updateType = null;
+
     /**
      * {@inheritdoc}
      */
     public function relations()
     {
         return [
-            'message'              => Message::class,
-            'edited_message'       => EditedMessage::class,
-            'channel_post'         => Message::class,
-            'edited_channel_post'  => EditedMessage::class,
-            'inline_query'         => InlineQuery::class,
+            'message' => Message::class,
+            'edited_message' => EditedMessage::class,
+            'channel_post' => Message::class,
+            'edited_channel_post' => EditedMessage::class,
+            'inline_query' => InlineQuery::class,
             'chosen_inline_result' => ChosenInlineResult::class,
-            'callback_query'       => CallbackQuery::class,
-            'shipping_query'       => ShippingQuery::class,
-            'pre_checkout_query'   => PreCheckoutQuery::class,
-            'poll'                 => Poll::class,
+            'callback_query' => CallbackQuery::class,
+            'shipping_query' => ShippingQuery::class,
+            'pre_checkout_query' => PreCheckoutQuery::class,
+            'poll' => Poll::class,
+            'poll_answer' => PollAnswer::class,
+            'my_chat_member' => ChatMemberUpdated::class,
+            'chat_member' => ChatMemberUpdated::class,
+            'chat_join_request' => ChatJoinRequest::class,
         ];
     }
 
@@ -72,7 +85,20 @@ class Update extends BaseObject
     }
 
     /**
+     * Update type.
+     *
+     * @return string|null
+     */
+    public function objectType(): ?string
+    {
+        return $this->updateType ??= $this->except('update_id')
+            ->keys()
+            ->first();
+    }
+
+    /**
      * Detect type based on properties.
+     * @deprecated Will be removed in v4.0, please use {@see \Telegram\Bot\Objects\Update::objectType} instead.
      *
      * @return string|null
      */

--- a/src/Objects/Update.php
+++ b/src/Objects/Update.php
@@ -41,20 +41,20 @@ class Update extends BaseObject
     public function relations()
     {
         return [
-            'message' => Message::class,
-            'edited_message' => EditedMessage::class,
-            'channel_post' => Message::class,
-            'edited_channel_post' => EditedMessage::class,
-            'inline_query' => InlineQuery::class,
-            'chosen_inline_result' => ChosenInlineResult::class,
-            'callback_query' => CallbackQuery::class,
-            'shipping_query' => ShippingQuery::class,
-            'pre_checkout_query' => PreCheckoutQuery::class,
-            'poll' => Poll::class,
-            'poll_answer' => PollAnswer::class,
-            'my_chat_member' => ChatMemberUpdated::class,
-            'chat_member' => ChatMemberUpdated::class,
-            'chat_join_request' => ChatJoinRequest::class,
+            'message'               => Message::class,
+            'edited_message'        => EditedMessage::class,
+            'channel_post'          => Message::class,
+            'edited_channel_post'   => EditedMessage::class,
+            'inline_query'          => InlineQuery::class,
+            'chosen_inline_result'  => ChosenInlineResult::class,
+            'callback_query'        => CallbackQuery::class,
+            'shipping_query'        => ShippingQuery::class,
+            'pre_checkout_query'    => PreCheckoutQuery::class,
+            'poll'                  => Poll::class,
+            'poll_answer'           => PollAnswer::class,
+            'my_chat_member'        => ChatMemberUpdated::class,
+            'chat_member'           => ChatMemberUpdated::class,
+            'chat_join_request'     => ChatJoinRequest::class,
         ];
     }
 
@@ -129,7 +129,7 @@ class Update extends BaseObject
     /**
      * Get the message contained in the Update.
      *
-     * @return Message|EditedMessage|Collection
+     * @return Message|InlineQuery|ChosenInlineResult|CallbackQuery|ShippingQuery|PreCheckoutQuery|Poll|PollAnswer|Collection
      */
     public function getMessage(): Collection
     {

--- a/src/Objects/User.php
+++ b/src/Objects/User.php
@@ -5,13 +5,17 @@ namespace Telegram\Bot\Objects;
 /**
  * Class User.
  *
+ * @link https://core.telegram.org/bots/api#user
  *
- * @property int         $id             Unique identifier for this user or bot.
- * @property bool        $isBot          True, if this user is a bot
- * @property string      $firstName      User's or bot's first name.
- * @property string|null $lastName       (Optional). User's or bot's last name.
- * @property string|null $username       (Optional). User's or bot's username.
- * @property string|null $languageCode   (Optional). IETF language tag of the user's language
+ * @property int         $id                            Unique identifier for this user or bot.
+ * @property bool        $isBot                         True, if this user is a bot
+ * @property string      $firstName                     User's or bot's first name.
+ * @property string|null $lastName                      (Optional). User's or bot's last name.
+ * @property string|null $username                      (Optional). User's or bot's username.
+ * @property string|null $languageCode                  (Optional). IETF language tag of the user's language
+ * @property bool|null   $canJoinGroups                 (Optional). True, if the bot can be invited to groups. Returned only in getMe.
+ * @property bool|null   $canReadAllGroupMessages       (Optional). True, if privacy mode is disabled for the bot. Returned only in getMe.
+ * @property bool|null   $supportsInlineQueries         (Optional). True, if the bot supports inline queries. Returned only in getMe.
  */
 class User extends BaseObject
 {

--- a/src/Objects/UserProfilePhotos.php
+++ b/src/Objects/UserProfilePhotos.php
@@ -5,6 +5,7 @@ namespace Telegram\Bot\Objects;
 /**
  * Class UserProfilePhotos.
  *
+ * @link https://core.telegram.org/bots/api#userprofilephotos
  *
  * @property int         $totalCount     Total number of profile pictures the target user has.
  * @property PhotoSize[] $photos         Requested profile pictures (in up to 4 sizes each).

--- a/src/Objects/UserProfilePhotos.php
+++ b/src/Objects/UserProfilePhotos.php
@@ -8,7 +8,7 @@ namespace Telegram\Bot\Objects;
  * @link https://core.telegram.org/bots/api#userprofilephotos
  *
  * @property int         $totalCount     Total number of profile pictures the target user has.
- * @property PhotoSize[] $photos         Requested profile pictures (in up to 4 sizes each).
+ * @property PhotoSize[] $photos         Array of Array of PhotoSize. Requested profile pictures (in up to 4 sizes each).
  */
 class UserProfilePhotos extends BaseObject
 {

--- a/src/Objects/Venue.php
+++ b/src/Objects/Venue.php
@@ -5,12 +5,15 @@ namespace Telegram\Bot\Objects;
 /**
  * Class Venue.
  *
+ * @link https://core.telegram.org/bots/api#venue
  *
- * @property Location    $location        Venue location.
- * @property string      $title           Name of the venue.
- * @property string      $address         Address of the venue.
- * @property string|null $foursquareId    (Optional). Foursquare identifier of the venue.
- * @property string|null $foursquareType  (Optional). Foursquare type of the venue. (For example, “arts_entertainment/default”, “arts_entertainment/aquarium” or “food/icecream”.)
+ * @property Location    $location          Venue location.
+ * @property string      $title             Name of the venue.
+ * @property string      $address           Address of the venue.
+ * @property string|null $foursquareId      (Optional). Foursquare identifier of the venue.
+ * @property string|null $foursquareType    (Optional). Foursquare type of the venue. (For example, “arts_entertainment/default”, “arts_entertainment/aquarium” or “food/icecream”.)
+ * @property string|null $googlePlaceId     (Optional). Google Places identifier of the venue
+ * @property string|null $googlePlaceType   (Optional). Google Places type of the venue. (
  */
 class Venue extends BaseObject
 {

--- a/src/Objects/Video.php
+++ b/src/Objects/Video.php
@@ -5,6 +5,7 @@ namespace Telegram\Bot\Objects;
 /**
  * Class Video.
  *
+ * @link https://core.telegram.org/bots/api#video
  *
  * @property string         $fileId         Unique identifier for this file.
  * @property string         $fileUniqueId   Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
@@ -12,6 +13,7 @@ namespace Telegram\Bot\Objects;
  * @property int            $height         Video height as defined by sender.
  * @property int            $duration       Duration of the video in seconds as defined by sender.
  * @property PhotoSize|null $thumb          (Optional). Video thumbnail.
+ * @property string|null    $fileName       (Optional). Original filename as defined by sender
  * @property string|null    $mimeType       (Optional). Mime type of a file as defined by sender.
  * @property int|null       $fileSize       (Optional). File size.
  */

--- a/src/Objects/VideoNote.php
+++ b/src/Objects/VideoNote.php
@@ -3,14 +3,14 @@
 namespace Telegram\Bot\Objects;
 
 /**
+ * @link https://core.telegram.org/bots/api#videonote
+ *
  * @property string         $fileId         Unique identifier for this file.
  * @property string         $fileUniqueId   Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
  * @property int            $length         Video width and height as defined by sender.
  * @property int            $duration       Duration of the video in seconds as defined by sender.
  * @property PhotoSize|null $thumb          (Optional). Video thumbnail.
  * @property int|null       $fileSize       (Optional). File size.
- *
- * @link https://core.telegram.org/bots/api#videonote
  */
 class VideoNote extends BaseObject
 {

--- a/src/Objects/Voice.php
+++ b/src/Objects/Voice.php
@@ -5,6 +5,7 @@ namespace Telegram\Bot\Objects;
 /**
  * Class Voice.
  *
+ * @link https://core.telegram.org/bots/api#voice
  *
  * @property string      $fileId         Unique identifier for this file.
  * @property string      $fileUniqueId   Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.

--- a/src/Objects/VoiceChatEnded.php
+++ b/src/Objects/VoiceChatEnded.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Telegram\Bot\Objects;
+
+/**
+ * Class VoiceChatEnded.
+ *
+ * @link https://core.telegram.org/bots/api#voicechatended
+ *
+ * @property int $duration         Voice chat duration in seconds
+ */
+class VoiceChatEnded extends BaseObject
+{
+    /** @inheritDoc */
+    public function relations()
+    {
+        return [];
+    }
+}

--- a/src/Objects/VoiceChatParticipantsInvited.php
+++ b/src/Objects/VoiceChatParticipantsInvited.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Telegram\Bot\Objects;
+
+/**
+ * Class VoiceChatParticipantsInvited.
+ *
+ * @link https://core.telegram.org/bots/api#voicechatended
+ *
+ * @property User[]|null $users    (Optional). New members that were invited to the voice chat
+ */
+class VoiceChatParticipantsInvited extends BaseObject
+{
+    /** @inheritDoc */
+    public function relations()
+    {
+        return [
+            'users' => [User::class],
+        ];
+    }
+}

--- a/src/Objects/VoiceChatScheduled.php
+++ b/src/Objects/VoiceChatScheduled.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Telegram\Bot\Objects;
+
+/**
+ * Class VoiceChatScheduled.
+ *
+ * @link https://core.telegram.org/bots/api#voicechatscheduled
+ *
+ * @property int $start_date  Point in time (Unix timestamp) when the voice chat is supposed to be started by a chat administrator
+ */
+class VoiceChatScheduled extends BaseObject
+{
+    /** @inheritDoc */
+    public function relations()
+    {
+        return [];
+    }
+}

--- a/src/Objects/VoiceChatStarted.php
+++ b/src/Objects/VoiceChatStarted.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Telegram\Bot\Objects;
+
+/**
+ * Class VoiceChatStarted.
+ *
+ * @link https://core.telegram.org/bots/api#voicechatstarted
+ *
+ */
+class VoiceChatStarted extends BaseObject
+{
+    /** @inheritDoc */
+    public function relations()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
## Before review
It's better to firstly merge https://github.com/irazasyed/telegram-bot-sdk/pull/966 (where I've fixed tests on CI). Tests failing for a long time, it's not caused by this PR

## Description
Backport includes:
 - missing types
 - some methods
 - PHPDoc

Goals:
 - simplify migration to v4 (I've also added few deprecation notes to methods not exist in v4)