### PR TITLE
Drop PHP 7.2 support and update phpunit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     paths:
       - 'src/**'
@@ -19,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         php: ['7.3', '7.4', '8.0', '8.1', '8.2']
         laravel: [5.5.*, 6.*, 7.*, '^8.0', '^9.0']
@@ -29,6 +30,8 @@ jobs:
             php: '7.3'
           - laravel: '^9.0'
             php: '7.4'
+          - dependency-version: 'prefer-lowest'
+            php: '8.0'
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         php: ['7.3', '7.4', '8.0', '8.1', '8.2']
         laravel: [5.5.*, 6.*, 7.*, '^8.0', '^9.0']
@@ -30,8 +30,6 @@ jobs:
             php: '7.3'
           - laravel: '^9.0'
             php: '7.4'
-          - dependency-version: 'prefer-lowest'
-            php: '8.0'
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,14 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: ['7.2', '7.3', '7.4', '8.0']
-        laravel: [5.5.*, 6.*, 7.*, '^8.0']
+        php: ['7.3', '7.4', '8.0', '8.1', '8.2']
+        laravel: [5.5.*, 6.*, 7.*, '^8.0', '^9.0']
         dependency-version: [prefer-lowest, prefer-stable]
         exclude:
-          - php: '7.2'
-            laravel: '^8.0'
+          - laravel: '^9.0'
+            php: '7.3'
+          - laravel: '^9.0'
+            php: '7.4'
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
     env:

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ composer.phar
 composer.lock
 vendor/
 build/
+.phpunit.result.cache

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 vendor/
 build/
 .phpunit.result.cache
+.phpunit.cache

--- a/composer.json
+++ b/composer.json
@@ -13,14 +13,15 @@
     }
   ],
   "require": {
-    "php": "^7.2 || ^8.0",
+    "php": ">=7.3",
+    "ext-json": "*",
     "guzzlehttp/guzzle": "^6.3 || ^7.0.1",
     "guzzlehttp/psr7": "^1.4 || ^2",
     "illuminate/support": "5.5 - 9",
     "league/event": "^2.1"
   },
   "require-dev": {
-    "phpunit/phpunit": "^8.5 || ^9.0"
+    "phpunit/phpunit": "^9.0 || ^10.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "league/event": "^2.1"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0 || ^10.0"
+    "phpunit/phpunit": "^9.5"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,10 @@
   },
   "config": {
     "preferred-install": "dist",
-    "sort-packages": true
+    "sort-packages": true,
+    "allow-plugins": {
+      "kylekatarnls/update-helper": true
+    }
   },
   "minimum-stability": "dev",
   "prefer-stable": true

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
          backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"
@@ -9,17 +11,17 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false">
+    <coverage>
+        <include>
+            <directory suffix=".php">src/</directory>
+        </include>
+        <exclude>
+            <directory suffix=".php">src/Laravel/config/</directory>
+        </exclude>
+    </coverage>
     <testsuites>
-        <testsuite name="Telegram Bot PHP SDK Test Suite">
-            <directory suffix="Test.php">tests/</directory>
+        <testsuite name="Telegram Bot SDK Test Suite">
+            <directory suffix="Test.php">tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-            <exclude>
-                <directory suffix=".php">src/Laravel/config/</directory>
-            </exclude>
-        </whitelist>
-    </filter>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,23 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"
          verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
-    <coverage>
+         cacheResultFile=".phpunit.cache/test-results"
+         executionOrder="depends,defects"
+         forceCoversAnnotation="false"
+         beStrictAboutCoversAnnotation="false"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutTodoAnnotatedTests="true"
+         convertDeprecationsToExceptions="true"
+         failOnRisky="false"
+         failOnWarning="false">
+    <coverage
+        cacheDirectory=".phpunit.cache/code-coverage"
+        processUncoveredFiles="true">
         <include>
-            <directory suffix=".php">src/</directory>
+            <directory suffix=".php">src</directory>
         </include>
-        <exclude>
-            <directory suffix=".php">src/Laravel/config/</directory>
-        </exclude>
     </coverage>
     <testsuites>
         <testsuite name="Telegram Bot SDK Test Suite">


### PR DESCRIPTION
Goals:
 - fix tests on CI (phpunit 8.X can't be installed on php 7.2)
 - help PHP ecosystem by forcing developers using supported PHP version (all versions older 7.4 are [EOL](https://www.php.net/supported-versions.php))