### PR TITLE
Fix type issue parsing "entities"

### DIFF
--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -5,6 +5,7 @@ namespace Telegram\Bot\Commands;
 use Illuminate\Support\Collection;
 use Telegram\Bot\Answers\Answerable;
 use Telegram\Bot\Api;
+use Telegram\Bot\Objects\MessageEntity;
 use Telegram\Bot\Objects\Update;
 
 /**
@@ -352,8 +353,8 @@ abstract class Command implements CommandInterface
             collect() :
             $message
                 ->get('entities', collect())
-                ->filter(function ($entity) {
-                    return $entity['type'] === 'bot_command';
+                ->filter(function (MessageEntity $entity) {
+                    return $entity->type === 'bot_command';
                 })
                 ->pluck('offset');
     }

--- a/src/Traits/CommandsHandler.php
+++ b/src/Traits/CommandsHandler.php
@@ -111,7 +111,7 @@ trait CommandsHandler
      *
      * @param string $name   Command Name
      * @param Update $update Update Object
-     * @param null   $entity
+     * @param array|null $entity
      *
      * @return mixed
      */


### PR DESCRIPTION
## Before review
It's better to firstly merge https://github.com/irazasyed/telegram-bot-sdk/pull/966 (where I've fixed tests on CI). Tests failing for a long time, it's not caused by this PR


## Description
Because we fixed one-to-many relationships, now we have collections on objects instead of collections of arrays.

Currently I've located a related bug caused by a change in this line: https://github.com/koot-labs/telegram-bot-sdk-v3/commit/55c2b7e2b8b5f850a646948e042bb79b8e46a8ae#diff-57d0f563404fb108cfd0cbe4edfec9b74c6ad896942dcff31be394e8dd7461e4R74


the fix is ready and tested on a live bot