### PR TITLE
Fix package to work on PHP 7.3 (do not use PHP 7.4 syntax)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,4 +79,7 @@ jobs:
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest --ignore-platform-req=php
 
       - name: Execute tests
-        run: vendor/bin/phpunit
+        run: composer test
+
+      - name: Check .php files for syntax errors
+        run: composer php:syntax -- --checkstyle | cs2pr

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,3 +83,14 @@ jobs:
 
       - name: Check .php files for syntax errors
         run: composer php:syntax -- --checkstyle | cs2pr
+
+      - uses: actions/cache@v3
+        id: cache-db
+        with:
+          path: ~/.symfony/cache
+          key: db
+
+      - name: Check composer dependencies for known security issues
+        uses: symfonycorp/security-checker-action@v3
+        with:
+          lock: ./composer.lock

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     "league/event": "^2.1"
   },
   "require-dev": {
+    "php-parallel-lint/php-parallel-lint": "^1.3",
     "phpunit/phpunit": "^9.5"
   },
   "autoload": {
@@ -38,6 +39,7 @@
     "illuminate/container": "Hold dependencies to be injected in commands constructors"
   },
   "scripts": {
+    "php:syntax": "parallel-lint . --blame --colors --exclude vendor",
     "test": "phpunit"
   },
   "extra": {

--- a/src/Objects/Update.php
+++ b/src/Objects/Update.php
@@ -33,7 +33,8 @@ use Telegram\Bot\Objects\Updates\PollAnswer;
  */
 class Update extends BaseObject
 {
-    protected ?string $updateType = null;
+    /** @var string|null Cached type of thr Update () */
+    protected $updateType = null;
 
     /**
      * {@inheritdoc}

--- a/src/Objects/Update.php
+++ b/src/Objects/Update.php
@@ -92,7 +92,7 @@ class Update extends BaseObject
      */
     public function objectType(): ?string
     {
-        return $this->updateType ??= $this->except('update_id')
+        return $this->updateType ?: $this->except('update_id')
             ->keys()
             ->first();
     }


### PR DESCRIPTION
It's fixed by https://github.com/irazasyed/telegram-bot-sdk/commit/34071a1be300db0e8bd8f78c4d86aa8bbbaebb72


Additionally, I've added few more checks on CI:
 - check PHP syntax using [parallel-lint](https://github.com/php-parallel-lint/PHP-Parallel-Lint) 7231b57729ff45dc64b8f19231a8017d20d7bc4c
 - check composer dependencies for known security issues fc8d43af9f400a979fad093a474d22ec487aa582


New GitHub workflow steps are fast, no need to extract them into a parallel job as PHP preparation with composer install slower than these steps