### PR TITLE
Fix CI: do not use guzzle versions with know vulnerabilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,4 +79,7 @@ jobs:
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest --ignore-platform-req=php
 
       - name: Execute tests
-        run: vendor/bin/phpunit
+        run: composer test
+
+      - name: Check .php files for syntax errors
+        run: composer php:syntax -- --checkstyle | cs2pr

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
           php-version: ${{ matrix.php }}
           extensions: ${{ env.EXTENSIONS }}
           coverage: none #pcov
+          tools: cs2pr
 
       - name: Get composer cache directory
         id: composer-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,3 +83,14 @@ jobs:
 
       - name: Check .php files for syntax errors
         run: composer php:syntax -- --checkstyle | cs2pr
+
+      - uses: actions/cache@v3
+        id: cache-db
+        with:
+          path: ~/.symfony/cache
+          key: db
+
+      - name: Check composer dependencies for known security issues
+        uses: symfonycorp/security-checker-action@v3
+        with:
+          lock: ./composer.lock

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     "league/event": "^2.1"
   },
   "require-dev": {
+    "php-parallel-lint/php-parallel-lint": "^1.3",
     "phpunit/phpunit": "^9.5"
   },
   "autoload": {
@@ -38,6 +39,7 @@
     "illuminate/container": "Hold dependencies to be injected in commands constructors"
   },
   "scripts": {
+    "php:syntax": "parallel-lint . --blame --colors --exclude vendor",
     "test": "phpunit"
   },
   "extra": {

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
   "require": {
     "php": ">=7.3",
     "ext-json": "*",
-    "guzzlehttp/guzzle": "^6.3 || ^7.0.1",
-    "guzzlehttp/psr7": "^1.4 || ^2",
+    "guzzlehttp/guzzle": "^6.5.8 || ^7.4.5",
+    "guzzlehttp/psr7": "^1.9 || ^2.2",
     "illuminate/support": "5.5 - 9",
     "league/event": "^2.1"
   },

--- a/src/Objects/Update.php
+++ b/src/Objects/Update.php
@@ -33,7 +33,8 @@ use Telegram\Bot\Objects\Updates\PollAnswer;
  */
 class Update extends BaseObject
 {
-    protected ?string $updateType = null;
+    /** @var string|null Cached type of thr Update () */
+    protected $updateType = null;
 
     /**
      * {@inheritdoc}

--- a/src/Objects/Update.php
+++ b/src/Objects/Update.php
@@ -92,7 +92,7 @@ class Update extends BaseObject
      */
     public function objectType(): ?string
     {
-        return $this->updateType ??= $this->except('update_id')
+        return $this->updateType ?: $this->except('update_id')
             ->keys()
             ->first();
     }

--- a/src/Objects/Update.php
+++ b/src/Objects/Update.php
@@ -92,9 +92,13 @@ class Update extends BaseObject
      */
     public function objectType(): ?string
     {
-        return $this->updateType ?: $this->except('update_id')
-            ->keys()
-            ->first();
+        if ($this->updateType === null ) {
+            $this->updateType = $this->except('update_id')
+                ->keys()
+                ->first();
+        }
+
+        return $this->updateType;
     }
 
     /**


### PR DESCRIPTION
Fix CI by:
 - Add missing `cs2pr` tool to CI (to report about PHP syntax issues as GitHub annotations)
 - Security: bump guzzle versions to do not use packages with known vulnerabilities