### PR TITLE
Improve PHPDoc (for Telegram + add more deprecations to methods removed in SDK v4)

### DIFF
--- a/src/BotsManager.php
+++ b/src/BotsManager.php
@@ -213,6 +213,8 @@ class BotsManager
     }
 
     /**
+     * @deprecated Will be removed in SDK v4
+     * @internal
      * Builds the list of commands for the given commands array.
      *
      * @param array $commands

--- a/src/Laravel/Facades/Telegram.php
+++ b/src/Laravel/Facades/Telegram.php
@@ -7,6 +7,13 @@ use Illuminate\Support\Facades\Facade;
 
 /**
  * Class Telegram.
+ *
+ * @method static bool getBots(string $name):list<\Telegram\Bot\Api>
+ * @method static bool bot(string|null $name):\Telegram\Bot\Api
+ * @method static bool reconnect(string|null $name):\Telegram\Bot\Api
+ * @method static bool disconnect(string|null $name):\Telegram\Bot\BotsManager
+ *
+ * @see \Telegram\Bot\BotsManager
  */
 class Telegram extends Facade
 {

--- a/src/Objects/BaseObject.php
+++ b/src/Objects/BaseObject.php
@@ -44,8 +44,8 @@ abstract class BaseObject extends Collection
     /**
      * Magically map to an object class (if exists) and return data.
      *
-     * @param      $property
-     * @param null $default
+     * @param string $property Name of the property or relation.
+     * @param mixed $default Default value or \Closure that returns default value.
      *
      * @return mixed
      */

--- a/src/Objects/Update.php
+++ b/src/Objects/Update.php
@@ -60,6 +60,7 @@ class Update extends BaseObject
     }
 
     /**
+     * @deprecated Will be removed in SDK v4
      * Get recent message.
      *
      * @return Update


### PR DESCRIPTION
 - add few more deprecation notes
 - add PHPDoc for `Telegram` facade to improve DX (it has not a complete list of public methods because missing ones will be probably removed on SDK v4)