### PR TITLE
Add php-cs-fixer to CI to use the same style as for SDK v4

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -1,0 +1,25 @@
+name: Code Style
+
+on: [push]
+
+jobs:
+  php-cs-fixer:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Run PHP CS Fixer
+        uses: docker://oskarstark/php-cs-fixer-ga
+        with:
+          args: --config=.php-cs-fixer.dist.php --allow-risky=yes
+
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Apply PHP CS Fixer changes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,44 @@
+<?php
+
+$finder = PhpCsFixer\Finder::create()
+    ->ignoreDotFiles(false)
+    ->ignoreVCSIgnored(true)
+    ->in(__DIR__)
+;
+
+return (new PhpCsFixer\Config())
+    ->setRules([
+        '@PSR2' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'not_operator_with_successor_space' => true,
+        'no_extra_blank_lines' => [
+            'tokens' => [
+                'curly_brace_block',
+                'extra',
+                'parenthesis_brace_block',
+                'throw',
+                'use',
+            ],
+        ],
+        'no_unused_imports' => true,
+        'ordered_imports' => ['sort_algorithm' => 'alpha'],
+        'ternary_operator_spaces' => true,
+        'single_blank_line_before_namespace' => true,
+
+        // PSR-12
+        'blank_line_after_opening_tag' => true,
+        'braces' => ['allow_single_line_closure' => true],
+        'compact_nullable_typehint' => true,
+        'concat_space' => ['spacing' => 'one'],
+        'declare_equal_normalize' => ['space' => 'none'],
+        'function_typehint_space' => true,
+        'new_with_braces' => true,
+        'method_argument_space' => ['on_multiline' => 'ensure_fully_multiline'],
+        'no_empty_statement' => true,
+        'no_leading_import_slash' => true,
+        'no_leading_namespace_whitespace' => true,
+        'no_whitespace_in_blank_line' => true,
+        'return_type_declaration' => ['space_before' => 'none'],
+        'single_trait_insert_per_statement' => true,
+    ])
+    ->setFinder($finder);


### PR DESCRIPTION
## ⚠️ Before review

As this PR merge may produce conflicts with other PRs, it's better to merge it as the latest one

## Description

Goals:
 - simplify migration to SDK v4 (using compare files tools)
 - unify styles across codebase

PS: php-cs-fixer config copied from SDK v4 repository