### PR TITLE
Make TelegramServiceProvider really deferrable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "ext-json": "*",
     "guzzlehttp/guzzle": "^6.5.8 || ^7.4.5",
     "guzzlehttp/psr7": "^1.9 || ^2.2",
-    "illuminate/support": "5.5 - 9",
+    "illuminate/support": "5.8 - 9",
     "league/event": "^2.1"
   },
   "require-dev": {

--- a/src/Laravel/TelegramServiceProvider.php
+++ b/src/Laravel/TelegramServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Telegram\Bot\Laravel;
 
+use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Foundation\Application as LaravelApplication;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Lumen\Application as LumenApplication;
@@ -12,7 +13,7 @@ use Telegram\Bot\Laravel\Artisan\WebhookCommand;
 /**
  * Class TelegramServiceProvider.
  */
-class TelegramServiceProvider extends ServiceProvider
+class TelegramServiceProvider extends ServiceProvider implements DeferrableProvider
 {
     /**
      * Register the service provider.


### PR DESCRIPTION
`DeferrableProvider` was introduced in Laravel 5.8: https://laravel.com/docs/5.8/upgrade#deferred-service-providers

Before it, it was possible to set `protected $defer = true;`, but this functionality was unused also.
Without it, TelegramServiceProvider::provides() is useless. (I can create a new PR for it if we don't want to bump Laravel version) [but even 5.8 is abandoned - see https://laravelversions.com/en]