### PR TITLE
Drop `username` config key used by WebhookCommand only

### DIFF
--- a/src/Laravel/Artisan/WebhookCommand.php
+++ b/src/Laravel/Artisan/WebhookCommand.php
@@ -18,9 +18,9 @@ class WebhookCommand extends Command
      * @var string
      */
     protected $signature = 'telegram:webhook {bot? : The bot name defined in the config file}
-                {--all : To perform actions on all your bots.} 
-                {--setup : To declare your webhook on Telegram servers. So they can call you.} 
-                {--remove : To remove your already declared webhook on Telegram servers.} 
+                {--all : To perform actions on all your bots.}
+                {--setup : To declare your webhook on Telegram servers. So they can call you.}
+                {--remove : To remove your already declared webhook on Telegram servers.}
                 {--info : To get the information about your current webhook on Telegram servers.}';
     /**
      * The console command description.
@@ -126,7 +126,7 @@ class WebhookCommand extends Command
 
         if ($this->hasArgument('bot') && ! $this->option('all')) {
             $response = $this->telegram->getWebhookInfo();
-            $this->makeWebhookInfoResponse($response, $this->config['username']);
+            $this->makeWebhookInfoResponse($response, $this->argument('bot'));
 
             return;
         }
@@ -135,7 +135,7 @@ class WebhookCommand extends Command
             $bots = $this->botsManager->getConfig('bots');
             collect($bots)->each(function ($bot, $key) {
                 $response = $this->botsManager->bot($key)->getWebhookInfo();
-                $this->makeWebhookInfoResponse($response, $bot['username']);
+                $this->makeWebhookInfoResponse($response, $key);
             });
         }
     }

--- a/src/Laravel/config/telegram.php
+++ b/src/Laravel/config/telegram.php
@@ -14,9 +14,6 @@ return [
     |
     | - name: The *personal* name you would like to refer to your bot as.
     |
-    |       - username: Your Telegram Bot's Username.
-    |                       Example: (string) 'BotFather'.
-    |
     |       - token:    Your Telegram Bot's Access Token.
                         Refer for more details: https://core.telegram.org/bots#botfather
     |                   Example: (string) '123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11'.
@@ -33,7 +30,6 @@ return [
     */
     'bots'                         => [
         'mybot' => [
-            'username'            => 'TelegramBot',
             'token'               => env('TELEGRAM_BOT_TOKEN', 'YOUR-BOT-TOKEN'),
             'certificate_path'    => env('TELEGRAM_CERTIFICATE_PATH', 'YOUR-CERTIFICATE-PATH'),
             'webhook_url'         => env('TELEGRAM_WEBHOOK_URL', 'YOUR-BOT-WEBHOOK-URL'),
@@ -43,7 +39,6 @@ return [
         ],
 
         //        'mySecondBot' => [
-        //            'username'  => 'AnotherTelegram_Bot',
         //            'token' => '123456:abc',
         //        ],
     ],


### PR DESCRIPTION
`username` config key (used by Laravel) confuses developer. It used by WebhookCommand only, so it's safe to be replaced by another bot name used for associative arrays as a key.