### PR TITLE
Add GitHub issue template for bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug_report.md
+++ b/.github/ISSUE_TEMPLATE/01-bug_report.md
@@ -1,0 +1,21 @@
+---
+name: "Bug report"
+about: "Report something that's broken. Please ensure there is no update with a bugfix you need: https://github.com/irazasyed/telegram-bot-sdk/releases"
+---
+
+<!-- DO NOT THROW THIS AWAY -->
+<!-- Fill out the FULL versions with patch versions -->
+
+- `irazasyed/telegram-bot-sdk` version: #.#.#
+- PHP Version: #.#.#
+- Laravel Version: #.#.# (optional)
+
+## Description:
+
+### Stacktrace:
+```
+```
+
+## Steps To Reproduce:
+
+<!-- If possible, please provide a GitHub repository to demonstrate your issue -->


### PR DESCRIPTION
Add GitHub issue template for bug reports.

Goals:
 - force bug reporters to provide more required for debugging information (to minimize number of reports like https://github.com/irazasyed/telegram-bot-sdk/issues/980)