### PR TITLE
Add missing @param and @return types to PHPDoc blocks

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -70,7 +70,7 @@ class Api
      * @deprecated This method will be removed in SDK v4.
      * Invoke Bots Manager.
      *
-     * @param $config
+     * @param array $config
      *
      * @return BotsManager
      */

--- a/src/BotsManager.php
+++ b/src/BotsManager.php
@@ -18,7 +18,7 @@ class BotsManager
     /** @var Container The container instance. */
     protected $container;
 
-    /** @var Api[] The active bot instances. */
+    /** @var array<string, Api> The active bot instances. */
     protected $bots = [];
 
     /**
@@ -34,7 +34,7 @@ class BotsManager
     /**
      * Set the IoC Container.
      *
-     * @param $container Container instance
+     * @param Container $container Container instance
      *
      * @return BotsManager
      */
@@ -72,7 +72,7 @@ class BotsManager
     /**
      * Get a bot instance.
      *
-     * @param string $name
+     * @param string|null $name
      *
      * @throws TelegramSDKException
      * @return Api
@@ -91,7 +91,7 @@ class BotsManager
     /**
      * Reconnect to the given bot.
      *
-     * @param string $name
+     * @param string|null $name
      *
      * @throws TelegramSDKException
      * @return Api
@@ -107,7 +107,7 @@ class BotsManager
     /**
      * Disconnect from the given bot.
      *
-     * @param string $name
+     * @param string|null $name
      *
      * @return BotsManager
      */
@@ -159,7 +159,7 @@ class BotsManager
     /**
      * Return all of the created bots.
      *
-     * @return Api[]
+     * @return array<string, Api>
      */
     public function getBots(): array
     {
@@ -217,7 +217,7 @@ class BotsManager
      * @internal
      * Builds the list of commands for the given commands array.
      *
-     * @param array $commands
+     * @param list<string|class-string<\Telegram\Bot\Commands\CommandInterface>> $commands A list of command names or FQCNs of CommandInterface instances.
      *
      * @return array An array of commands which includes global and bot specific commands.
      */
@@ -232,16 +232,12 @@ class BotsManager
     /**
      * Parse an array of commands and build a list.
      *
-     * @param array $commands
+     * @param list<string|class-string<\Telegram\Bot\Commands\CommandInterface>> $commands
      *
      * @return array
      */
     protected function parseCommands(array $commands): array
     {
-        if (! is_array($commands)) {
-            return $commands;
-        }
-
         $commandGroups = $this->getConfig('command_groups');
         $sharedCommands = $this->getConfig('shared_commands');
 

--- a/src/BotsManager.php
+++ b/src/BotsManager.php
@@ -9,6 +9,8 @@ use Telegram\Bot\Exceptions\TelegramSDKException;
 
 /**
  * Class BotsManager.
+ *
+ * @mixin \Telegram\Bot\Api
  */
 class BotsManager
 {

--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -106,7 +106,7 @@ abstract class Command implements CommandInterface
     /**
      * Set Command Description.
      *
-     * @param $description
+     * @param string $description
      *
      * @return Command
      */

--- a/src/Commands/CommandBus.php
+++ b/src/Commands/CommandBus.php
@@ -20,12 +20,12 @@ class CommandBus extends AnswerBus
     use Singleton;
 
     /**
-     * @var Command[] Holds all commands.
+     * @var array<string, Command> Holds all commands.
      */
     protected $commands = [];
 
     /**
-     * @var Command[] Holds all commands' aliases.
+     * @var array<string, Command> Holds all commands' aliases.
      */
     protected $commandAliases = [];
 
@@ -42,7 +42,7 @@ class CommandBus extends AnswerBus
     /**
      * Returns the list of commands.
      *
-     * @return array
+     * @return array<string, Command>
      */
     public function getCommands(): array
     {
@@ -52,7 +52,7 @@ class CommandBus extends AnswerBus
     /**
      * Add a list of commands.
      *
-     * @param array $commands
+     * @param list<CommandInterface|class-string<CommandInterface>> $commands
      *
      * @throws TelegramSDKException
      * @return CommandBus
@@ -69,7 +69,7 @@ class CommandBus extends AnswerBus
     /**
      * Add a command to the commands list.
      *
-     * @param CommandInterface|string $command Either an object or full path to the command class.
+     * @param CommandInterface|class-string<CommandInterface> $command Either an object or fully qualified class name (FQCN) of the command class.
      *
      * @throws TelegramSDKException
      *
@@ -104,7 +104,7 @@ class CommandBus extends AnswerBus
     /**
      * Remove a command from the list.
      *
-     * @param $name
+     * @param string $name Command's name
      *
      * @return CommandBus
      */
@@ -118,7 +118,7 @@ class CommandBus extends AnswerBus
     /**
      * Removes a list of commands.
      *
-     * @param array $names
+     * @param list<string> $names Command names
      *
      * @return CommandBus
      */
@@ -134,9 +134,9 @@ class CommandBus extends AnswerBus
     /**
      * Parse a Command for a Match.
      *
-     * @param $text
-     * @param $offset
-     * @param $length
+     * @param string $text
+     * @param int $offset
+     * @param int $length
      *
      * @return string
      */
@@ -164,7 +164,7 @@ class CommandBus extends AnswerBus
     /**
      * Handles Inbound Messages and Executes Appropriate Command.
      *
-     * @param $update
+     * @param Update $update
      *
      * @return Update
      */
@@ -188,7 +188,7 @@ class CommandBus extends AnswerBus
     /**
      * Returns all bot_commands detected in the update.
      *
-     * @param $message
+     * @param \Telegram\Bot\Objects\Message|Collection $message
      *
      * @return Collection<int, MessageEntity>
      */
@@ -203,7 +203,7 @@ class CommandBus extends AnswerBus
     /**
      * Execute a bot command from the update text.
      *
-     * @param array  $entity
+     * @param array<string, mixed> $entity
      * @param Update $update
      */
     protected function process($entity, Update $update)
@@ -222,7 +222,7 @@ class CommandBus extends AnswerBus
      *
      * @param string $name
      * @param Update $update
-     * @param array  $entity
+     * @param array<string, mixed> $entity
      *
      * @return mixed
      */
@@ -239,9 +239,9 @@ class CommandBus extends AnswerBus
     }
 
     /**
-     * @param $command
+     * @param CommandInterface|class-string<CommandInterface> $command
      *
-     * @return object
+     * @return CommandInterface
      * @throws TelegramSDKException
      */
     private function resolveCommand($command)
@@ -261,9 +261,10 @@ class CommandBus extends AnswerBus
     }
 
     /**
-     * @param $command
-     * @param $alias
+     * @param CommandInterface $command
+     * @param string $alias
      *
+     * @return void
      * @throws TelegramSDKException
      */
     private function checkForConflicts($command, $alias)
@@ -290,7 +291,7 @@ class CommandBus extends AnswerBus
     }
 
     /**
-     * @param $command
+     * @param CommandInterface|class-string<CommandInterface> $command
      *
      * @return object
      * @throws TelegramSDKException

--- a/src/Commands/CommandBus.php
+++ b/src/Commands/CommandBus.php
@@ -20,12 +20,12 @@ class CommandBus extends AnswerBus
     use Singleton;
 
     /**
-     * @var array<string, Command> Holds all commands.
+     * @var array<string, Command> Holds all commands. Keys are command names (without leading slashes).
      */
     protected $commands = [];
 
     /**
-     * @var array<string, Command> Holds all commands' aliases.
+     * @var array<string, Command> Holds all commands' aliases. Keys are command names (without leading slashes).
      */
     protected $commandAliases = [];
 
@@ -104,7 +104,7 @@ class CommandBus extends AnswerBus
     /**
      * Remove a command from the list.
      *
-     * @param string $name Command's name
+     * @param string $name Command's name without leading slash
      *
      * @return CommandBus
      */
@@ -134,11 +134,11 @@ class CommandBus extends AnswerBus
     /**
      * Parse a Command for a Match.
      *
-     * @param string $text
+     * @param string $text Command name with a leading slash
      * @param int $offset
      * @param int $length
      *
-     * @return string
+     * @return string Telegram command name (without leading slash)
      */
     public function parseCommand($text, $offset, $length): string
     {
@@ -146,6 +146,7 @@ class CommandBus extends AnswerBus
             throw new InvalidArgumentException('Message is empty, Cannot parse for command');
         }
 
+        // remove leading slash
         $command = substr(
             $text,
             $offset + 1,
@@ -203,7 +204,7 @@ class CommandBus extends AnswerBus
     /**
      * Execute a bot command from the update text.
      *
-     * @param array<string, mixed> $entity
+     * @param array<string, mixed> $entity {@see \Telegram\Bot\Objects\MessageEntity} object attributes.
      * @param Update $update
      */
     protected function process($entity, Update $update)
@@ -220,7 +221,7 @@ class CommandBus extends AnswerBus
     /**
      * Execute the command.
      *
-     * @param string $name
+     * @param string $name Telegram command name without leading slash
      * @param Update $update
      * @param array<string, mixed> $entity
      *

--- a/src/Events/EmitsEvents.php
+++ b/src/Events/EmitsEvents.php
@@ -85,6 +85,8 @@ trait EmitsEvents
 
     /**
      * @param $event
+     *
+     * @return void
      */
     private function validateEvent($event)
     {

--- a/src/Laravel/Facades/Telegram.php
+++ b/src/Laravel/Facades/Telegram.php
@@ -8,12 +8,12 @@ use Telegram\Bot\BotsManager;
 /**
  * Class Telegram.
  *
- * @method static bool getBots(string $name):list<\Telegram\Bot\Api>
- * @method static bool bot(string|null $name):\Telegram\Bot\Api
- * @method static bool reconnect(string|null $name):\Telegram\Bot\Api
- * @method static bool disconnect(string|null $name):\Telegram\Bot\BotsManager
+ * @method static list<\Telegram\Bot\Api> getBots(string $name)
+ * @method static \Telegram\Bot\Api bot(string|null $name)
+ * @method static \Telegram\Bot\Api reconnect(string|null $name)
+ * @method static \Telegram\Bot\BotsManager disconnect(string|null $name)
  *
- * @see \Telegram\Bot\BotsManager
+ * @mixin \Telegram\Bot\BotsManager
  */
 class Telegram extends Facade
 {

--- a/src/TelegramClient.php
+++ b/src/TelegramClient.php
@@ -132,7 +132,7 @@ class TelegramClient
 
     /**
      * @param TelegramRequest $request
-     * @param $method
+     * @param string $method
      *
      * @return array
      */

--- a/src/TelegramRequest.php
+++ b/src/TelegramRequest.php
@@ -64,7 +64,7 @@ class TelegramRequest
     /**
      * Make this request asynchronous (non-blocking).
      *
-     * @param $isAsyncRequest
+     * @param bool $isAsyncRequest
      *
      * @return TelegramRequest
      */

--- a/src/Traits/CommandsHandler.php
+++ b/src/Traits/CommandsHandler.php
@@ -107,6 +107,7 @@ trait CommandsHandler
     }
 
     /**
+     * @deprecated This method will be protected and signature will be changed in SDK v4.
      * Helper to Trigger Commands.
      *
      * @param string $name   Command Name


### PR DESCRIPTION
Goals: help IDE and static analysis tools to help developers :)

The PR doesn't contain any known BC changes