### PR TITLE
FIX: Set correct Api/Bot instance when add/init Commands

### DIFF
--- a/src/Commands/CommandBus.php
+++ b/src/Commands/CommandBus.php
@@ -249,8 +249,9 @@ class CommandBus extends AnswerBus
         if (! is_a($command, CommandInterface::class, true)) {
             throw new TelegramSDKException(
                 sprintf(
-                    'Command class "%s" should be an instance of "Telegram\Bot\Commands\CommandInterface"',
-                    get_class($command)
+                    'Command class "%s" should be an instance of "%s"',
+                    is_object($command) ? get_class($command) : $command,
+                    CommandInterface::class
                 )
             );
         }
@@ -264,7 +265,7 @@ class CommandBus extends AnswerBus
         }
 
         if ($commandInstance instanceof Command && $this->telegram) {
-            $commandInstance->setTelegram($this->telegram);
+            $commandInstance->setTelegram($this->getTelegram());
         }
 
         return $commandInstance;
@@ -297,32 +298,5 @@ class CommandBus extends AnswerBus
                 )
             );
         }
-    }
-
-    /**
-     * @param $command
-     *
-     * @return object
-     * @throws TelegramSDKException
-     */
-    private function makeCommandObj($command)
-    {
-        if (is_object($command)) {
-            return $command;
-        }
-        if (! class_exists($command)) {
-            throw new TelegramSDKException(
-                sprintf(
-                    'Command class "%s" not found! Please make sure the class exists.',
-                    $command
-                )
-            );
-        }
-
-        if ($this->telegram->hasContainer()) {
-            return $this->buildDependencyInjectedAnswer($command);
-        }
-
-        return new $command();
     }
 }

--- a/tests/Traits/CommandGenerator.php
+++ b/tests/Traits/CommandGenerator.php
@@ -8,24 +8,38 @@ use Telegram\Bot\Commands\Command;
 trait CommandGenerator
 {
     /**
-     * @param       $numberRequired
-     * @param array $arguments
+     * @param int $numberRequired
      *
      * @return Collection
      */
-    private function commandGenerator($numberRequired, $arguments = [])
+    private function commandGenerator($numberRequired)
     {
         $range = range(1, $numberRequired, 1);
 
         return collect($range)
-            ->map(function ($int) use ($arguments) {
-                $mockCommand = $this->prophesize(Command::class);
-                $mockCommand->getName()->willReturn("MockCommand$int");
-                $mockCommand->getAliases()->willReturn(["MockAlias$int"]);
-                $mockCommand->getPattern()->willReturn('');
-                $mockCommand->getArguments()->willReturn([]);
+            ->map(function (int $instanceNumber) {
+                return new class ($instanceNumber) extends Command {
+                    private $instanceNumber;
 
-                return $mockCommand->reveal();
+                    public function __construct(int $instanceNumber)
+                    {
+                        $this->instanceNumber = $instanceNumber;
+                    }
+
+                    public function getName(): string
+                    {
+                        return "MockCommand$this->instanceNumber";
+                    }
+
+                    public function getAliases(): array
+                    {
+                        return ["MockAlias$this->instanceNumber"];
+                    }
+
+                    public function handle()
+                    {
+                    }
+                };
             });
     }
 }


### PR DESCRIPTION
There is a public method `\Telegram\Bot\Commands\CommandBus::addCommand($command)` that accepts `class-string<CommandInterface>`:

https://github.com/irazasyed/telegram-bot-sdk/blob/9466c47b6b1aba8c60010b4f281494469cdd1245/src/Commands/CommandBus.php#L69-L87


it calls private `resolveCommand `:
https://github.com/irazasyed/telegram-bot-sdk/blob/9466c47b6b1aba8c60010b4f281494469cdd1245/src/Commands/CommandBus.php#L241-L261

that calls weird  private `makeCommandObj`:
https://github.com/irazasyed/telegram-bot-sdk/blob/9466c47b6b1aba8c60010b4f281494469cdd1245/src/Commands/CommandBus.php#L292-L317


it seems like `makeCommandObj` built to initiate not `Command` instances only, but it initiates `Command` instances ONLY. But when it initiates then using `new` keyword or even using DI container, it does not set a custom Api/Bot instance - it always uses default:
```php
        if ($commandInstance instanceof Command && $this->telegram) {
            $commandInstance->setTelegram($this->telegram);
        }

        return $commandInstance;
```

As result, inside a command `$this->getTelegram()` always returns a default bot instance (what is wrong for multi-bot apps).

## Extra

1. I've also removed `makeCommandObj`. It was private, so this is not BC change. Also, `resolveCommand` method explicitly returns CommandInterface instances (I've added some type checks and return type).
2. I've [fixed](https://github.com/irazasyed/telegram-bot-sdk/pull/984/commits/c0e45089882dacd55f3eac75a8badc6cafcf0294) a flaky test: now we don't use `prophesize`  to instantiate Commands (`prophesize` is deprecated and will be removed in PHPUnit v10)