### PR TITLE
Fix return type error on method findType

### DIFF
--- a/src/Objects/BaseObject.php
+++ b/src/Objects/BaseObject.php
@@ -194,7 +194,7 @@ abstract class BaseObject extends Collection
      */
     protected function findType(array $types): ?string
     {
-        $this->keys()
+        return $this->keys()
             ->intersect($types)
             ->pop();
     }


### PR DESCRIPTION
This pull request fixes the following error on php7.4:
 `Return value of Telegram\Bot\Objects\BaseObject::findType() must be of the type string or null, none returned`

This error would not allow the method get-updates to run.