### PR TITLE
createChatInvitelink returns array and solves the create link issue

### DIFF
--- a/src/Methods/Chat.php
+++ b/src/Methods/Chat.php
@@ -6,6 +6,7 @@ use Telegram\Bot\Exceptions\TelegramSDKException;
 use Telegram\Bot\Objects\Chat as ChatObject;
 use Telegram\Bot\Objects\ChatMember;
 use Telegram\Bot\Traits\Http;
+use Telegram\Bot\Objects\ChatInviteLink;
 
 /**
  * Class Chat.
@@ -131,7 +132,7 @@ trait Chat
      * @throws TelegramSDKException
      * @return ChatInviteLink
      */
-    public function createChatInviteLink(array $params): ChatInviteLink
+    public function createChatInviteLink(array $params): array
     {
         return $this->post('createChatInviteLink', $params)->getResult();
     }

--- a/src/Methods/Chat.php
+++ b/src/Methods/Chat.php
@@ -132,9 +132,9 @@ trait Chat
      * @throws TelegramSDKException
      * @return ChatInviteLink
      */
-    public function createChatInviteLink(array $params): array
+    public function createChatInviteLink(array $params): ChatInviteLink
     {
-        return $this->post('createChatInviteLink', $params)->getResult();
+        return new ChatInviteLink($this->post('createChatInviteLink', $params)->getDecodedBody());
     }
 
     /**


### PR DESCRIPTION
when I call createChatInviteLink it says, return type array given 