### PR TITLE
Add new `ApiRequestSending` and `ApiResponseReceived` events

### DIFF
--- a/src/Events/ApiRequestSending.php
+++ b/src/Events/ApiRequestSending.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Telegram\Bot\Events;
+
+use League\Event\AbstractEvent;
+use Telegram\Bot\TelegramRequest;
+
+final class ApiRequestSending extends AbstractEvent
+{
+    /** @var \Telegram\Bot\TelegramRequest */
+    private $request;
+
+    public function __construct(TelegramRequest $request)
+    {
+        $this->request = $request;
+    }
+
+    public function getRequest(): TelegramRequest
+    {
+        return $this->request;
+    }
+}

--- a/src/Events/ApiResponseReceived.php
+++ b/src/Events/ApiResponseReceived.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace Telegram\Bot\Events;
+
+use League\Event\AbstractEvent;
+use Telegram\Bot\TelegramResponse;
+
+final class ApiResponseReceived extends AbstractEvent
+{
+    /** @var \Telegram\Bot\TelegramResponse */
+    private $response;
+
+    public function __construct(TelegramResponse $response)
+    {
+        $this->response = $response;
+    }
+
+    public function getResponse(): TelegramResponse
+    {
+        return $this->response;
+    }
+}

--- a/src/Traits/Http.php
+++ b/src/Traits/Http.php
@@ -3,6 +3,8 @@
 namespace Telegram\Bot\Traits;
 
 use InvalidArgumentException;
+use Telegram\Bot\Events\ApiResponseReceived;
+use Telegram\Bot\Events\ApiRequestSending;
 use Telegram\Bot\Exceptions\CouldNotUploadInputFile;
 use Telegram\Bot\Exceptions\TelegramSDKException;
 use Telegram\Bot\FileUpload\InputFile;
@@ -344,7 +346,17 @@ trait Http
     {
         $telegramRequest = $this->resolveTelegramRequest($method, $endpoint, $params);
 
-        return $this->lastResponse = $this->getClient()->sendRequest($telegramRequest);
+        if (method_exists($this, 'emitEvent')) {
+            $this->emitEvent(new ApiRequestSending($telegramRequest));
+        }
+
+        $response = $this->getClient()->sendRequest($telegramRequest);
+
+        if (method_exists($this, 'emitEvent')) {
+            $this->emitEvent(new ApiResponseReceived($response));
+        }
+
+        return $this->lastResponse = $response;
     }
 
     /**


### PR DESCRIPTION
This adds 2 new events:
 - `ApiRequestSending`
 - `ApiResponseReceived`


For far the package provides only a single event: `UpdateWasReceived`. Having the only one event it's possible to use event system for logging and other purposes - you don't have the full picture. These 2 new events is simple but powerful addition. 


I'm open to:
 - rename them
 - port them to SDK v4 (my long-term goal is to simplify migration to SDK v4)
 - remove `if (method_exists($this, 'emitEvent')) {` part -- I found it ugly, but there is no way to make code safe without interfaces when you use traits in that fashion.