### PR TITLE
Emit `UpdateEvent` event similar to SDK v4

### DIFF
--- a/src/Events/UpdateEvent.php
+++ b/src/Events/UpdateEvent.php
@@ -33,16 +33,4 @@ final class UpdateEvent extends AbstractEvent
     {
         return $this->eventName ?: get_class($this);
     }
-
-    /**
-     * @internal
-     * @deprecated Will be removed in SDK v4
-     */
-    public function cloneWithCustomName(string $eventName): UpdateEvent
-    {
-        $event = new self($this->telegram, $this->update);
-        $event->eventName = $eventName;
-
-        return $event;
-    }
 }

--- a/src/Events/UpdateEvent.php
+++ b/src/Events/UpdateEvent.php
@@ -10,27 +10,28 @@ final class UpdateEvent extends AbstractEvent
 {
     public const NAME = 'update';
 
+    /**
+     * @deprecated Will be removed in SDK v4
+     * @var string
+     */
+    private $name;
+
     /** @var \Telegram\Bot\Api */
     public $telegram;
 
     /** @var \Telegram\Bot\Objects\Update */
     public $update;
 
-    /**
-     * @deprecated Will be removed in SDK v4
-     * @var string|null
-     */
-    private $eventName = null;
-
-    public function __construct(Api $telegram, Update $update)
+    public function __construct(Api $telegram, Update $update, string $name = self::NAME)
     {
         $this->telegram = $telegram;
         $this->update = $update;
+        $this->name = $name;
     }
 
     /** @inheritDoc */
-    public function getName()
+    public function getName(): string
     {
-        return $this->eventName ?: get_class($this);
+        return $this->name;
     }
 }

--- a/src/Events/UpdateEvent.php
+++ b/src/Events/UpdateEvent.php
@@ -16,33 +16,33 @@ class UpdateEvent extends AbstractEvent
     /** @var \Telegram\Bot\Objects\Update */
     public $update;
 
+    /**
+     * @deprecated Will be removed in SDK v4
+     * @var string|null
+     */
+    private $eventName = null;
+
     public function __construct(Api $telegram, Update $update)
     {
         $this->telegram = $telegram;
         $this->update = $update;
     }
 
+    /** @inheritDoc */
+    public function getName()
+    {
+        return $this->eventName ?: get_class($this);
+    }
+
     /**
      * @internal
      * @deprecated Will be removed in SDK v4
      */
-    public function cloneWithCustomName(string $eventName): self
+    public function cloneWithCustomName(string $eventName): UpdateEvent
     {
-        return new class ($this->telegram, $this->update, $eventName) extends UpdateEvent {
-            /** @var string */
-            private $eventName;
+        $event = new self($this->telegram, $this->update);
+        $event->eventName = $eventName;
 
-            public function __construct(Api $telegram, Update $update, string $eventName)
-            {
-                $this->eventName = $eventName;
-                parent::__construct($telegram, $update);
-            }
-
-            /** @inheritDoc */
-            public function getName(): string
-            {
-                return $this->eventName;
-            }
-        };
+        return $event;
     }
 }

--- a/src/Events/UpdateEvent.php
+++ b/src/Events/UpdateEvent.php
@@ -10,8 +10,11 @@ class UpdateEvent extends AbstractEvent
 {
     public const NAME = 'update';
 
-    public Api $telegram;
-    public Update $update;
+    /** @var \Telegram\Bot\Api */
+    public $telegram;
+
+    /** @var \Telegram\Bot\Objects\Update */
+    public $update;
 
     public function __construct(Api $telegram, Update $update)
     {

--- a/src/Events/UpdateEvent.php
+++ b/src/Events/UpdateEvent.php
@@ -6,7 +6,7 @@ use League\Event\AbstractEvent;
 use Telegram\Bot\Api;
 use Telegram\Bot\Objects\Update;
 
-class UpdateEvent extends AbstractEvent
+final class UpdateEvent extends AbstractEvent
 {
     public const NAME = 'update';
 

--- a/src/Events/UpdateEvent.php
+++ b/src/Events/UpdateEvent.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Telegram\Bot\Events;
+
+use League\Event\AbstractEvent;
+use Telegram\Bot\Api;
+use Telegram\Bot\Objects\Update;
+
+class UpdateEvent extends AbstractEvent
+{
+    public const NAME = 'update';
+
+    public Api $telegram;
+    public Update $update;
+
+    public function __construct(Api $telegram, Update $update)
+    {
+        $this->telegram = $telegram;
+        $this->update = $update;
+    }
+
+    /**
+     * @internal
+     * @deprecated Will be removed in SDK v4
+     */
+    public function cloneWithCustomName(string $eventName): self
+    {
+        return new class ($this->telegram, $this->update, $eventName) extends UpdateEvent {
+            /** @var string */
+            private $eventName;
+
+            public function __construct(Api $telegram, Update $update, string $eventName)
+            {
+                $this->eventName = $eventName;
+                parent::__construct($telegram, $update);
+            }
+
+            /** @inheritDoc */
+            public function getName(): string
+            {
+                return $this->eventName;
+            }
+        };
+    }
+}

--- a/src/Methods/Update.php
+++ b/src/Methods/Update.php
@@ -236,13 +236,13 @@ trait Update
 
         $event = new UpdateEvent($this, $update);
 
-        $eventEmitter->emit($event->cloneWithCustomName(UpdateEvent::NAME));
+        $eventEmitter->emit(UpdateEvent::NAME, $event);
         $updateType = $update->objectType();
         if (is_string($updateType)) {
-            $eventEmitter->emit($event->cloneWithCustomName($updateType));
+            $eventEmitter->emit($update->objectType(), $event);
 
             if (null !== $update->getMessage()->objectType()) {
-                $eventEmitter->emit($event->cloneWithCustomName($updateType . '.' . $update->getMessage()->objectType()));
+                $eventEmitter->emit($update->objectType() . '.' . $update->getMessage()->objectType(), $event);
             }
         }
     }

--- a/src/Methods/Update.php
+++ b/src/Methods/Update.php
@@ -234,15 +234,14 @@ trait Update
 
         $eventEmitter = $this->eventEmitter;
 
-        $event = new UpdateEvent($this, $update);
-
-        $eventEmitter->emit(UpdateEvent::NAME, $event);
+        $eventEmitter->emit(new UpdateEvent($this, $update));
         $updateType = $update->objectType();
         if (is_string($updateType)) {
-            $eventEmitter->emit($update->objectType(), $event);
+            $eventEmitter->emit(new UpdateEvent($this, $update, $updateType));
 
-            if (null !== $update->getMessage()->objectType()) {
-                $eventEmitter->emit($update->objectType() . '.' . $update->getMessage()->objectType(), $event);
+            $messageType = $update->getMessage()->objectType();
+            if (null !== $messageType) {
+                $eventEmitter->emit(new UpdateEvent($this, $update, "$updateType.$messageType"));
             }
         }
     }

--- a/tests/Integration/TelegramApiTest.php
+++ b/tests/Integration/TelegramApiTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Telegram\Bot\Api;
 use Telegram\Bot\Commands\CommandBus;
+use Telegram\Bot\Events\UpdateEvent;
 use Telegram\Bot\Events\UpdateWasReceived;
 use Telegram\Bot\Exceptions\CouldNotUploadInputFile;
 use Telegram\Bot\Exceptions\TelegramResponseException;
@@ -44,6 +45,12 @@ class TelegramApiTest extends TestCase
     protected function getApi($client = null, $token = 'TELEGRAM_TOKEN', $async = false)
     {
         return new Api($token, $async, $client);
+    }
+
+    /** Create Request to emulate income Request from Telegram. */
+    private function createIncomeWebhookRequestInstance(array $updateData): Request
+    {
+        return new Request('POST', 'any', [], json_encode($updateData, \JSON_THROW_ON_ERROR));
     }
 
     /**
@@ -543,7 +550,27 @@ class TelegramApiTest extends TestCase
         //We can't pass test data to the webhook because it relies on the read only stream php://input
         $this->assertEmpty($update);
         $this->assertInstanceOf(Update::class, $update);
-        $emitter->emit(Argument::type(UpdateWasReceived::class))->shouldHaveBeenCalled();
+        $emitter->emit(Argument::type(UpdateWasReceived::class))->shouldHaveBeenCalledOnce();
+    }
+
+    /** @test */
+    public function it_emits_3_events_of_update_event_type()
+    {
+        $emitter = $this->prophesize(Emitter::class);
+
+        $api = $this->getApi();
+        $api->setEventEmitter($emitter->reveal());
+
+        $incomeWebhookRequest = $this->createIncomeWebhookRequestInstance([
+            'message' => [ // to help SDK to detect Update of "message" type and send 2nd event (with name "message")
+                'text' => 'any', // to help SDK to detect message type and send 3rd event (with name "message.text")
+            ],
+        ]);
+
+        $update = $api->getWebhookUpdate(true, $incomeWebhookRequest);
+
+        $this->assertInstanceOf(Update::class, $update);
+        $emitter->emit(Argument::type(UpdateEvent::class))->shouldHaveBeenCalledTimes(3);
     }
 
     /** @test */

--- a/tests/Integration/TelegramApiTest.php
+++ b/tests/Integration/TelegramApiTest.php
@@ -661,12 +661,12 @@ class TelegramApiTest extends TestCase
     private function createSpyListener(): \League\Event\ListenerInterface
     {
         return new class extends AbstractListener {
-            /** @var array<string, list<mixed>> */
+            /** @var array<string, list<\League\Event\EventInterface>> */
             public $events = [];
 
             public function handle(EventInterface $event)
             {
-                $this->events[$event->getName()][] = func_get_args();
+                $this->events[$event->getName()][] = $event;
             }
         };
     }


### PR DESCRIPTION
`UpdateEvent` event back-ported from SDK v4.

Differences with SDKv4 events:
 - event from SDKv4 has `public Bot $bot`, in current PR it's `public Api $telegram;`. Reason -- there is no `Bot` class in SDK v3.
 - in this PR this event extends `\League\Event\AbstractEvent` (because we use `league/event` events system here), in SDK v4 it doesn't extend any classes.
 - this PR has better test than in SDK v4 :)


## Challenges

SDK v3 has a weird feature, I don't know a reason why we have it. This is `$shouldEmitEvent` parameter:
```php
// in Update.php trait
public function getWebhookUpdate($shouldEmitEvent = true, ...
```


I decided to not touch it, always emit a new event and keep emitting the old one `UpdateWasReceived` depends on $shouldEmitEvent argument's value. Reason - it provides more consistency with SDK v4.