### PR TITLE
Fix false positives for `/help` command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
   },
   "require-dev": {
     "php-parallel-lint/php-parallel-lint": "^1.3",
+    "phpspec/prophecy": "^1.15",
     "phpunit/phpunit": "^9.5"
   },
   "autoload": {

--- a/src/Commands/CommandBus.php
+++ b/src/Commands/CommandBus.php
@@ -224,7 +224,6 @@ class CommandBus extends AnswerBus
     {
         $command = $this->commands[$name] ??
             $this->commandAliases[$name] ??
-            $this->commands['help'] ??
             collect($this->commands)->filter(function ($command) use ($name) {
                 return $command instanceof $name;
             })->first() ?? null;


### PR DESCRIPTION
For example, the path to the `/storage` folder is sent to the chat. Telegram defines `/storage` as a command, and the SDK, when it doesn't find one, calls the `/help` command because it was added to the bot.

It turns out that the bot reacts to someone else's command.