### PR TITLE
Use dependabot to update GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,9 @@ updates:
     interval: daily
     time: "23:30"
   open-pull-requests-limit: 10
+
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 10


### PR DESCRIPTION
Just a small change to keep repo and CI up to date 

I'll appreciate tagging this PR by `hacktoberfest-accepted` label. Thank you!