### PR TITLE
make BASE_BOT_URL customizable

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -47,10 +47,11 @@ class Api
      * @param  string  $token             The Telegram Bot API Access Token.
      * @param  bool  $async             (Optional) Indicates if the request to Telegram will be asynchronous (non-blocking).
      * @param  HttpClientInterface|null  $httpClientHandler (Optional) Custom HTTP Client Handler.
+     * @param  string|null  $base_bot_url (Optional) Custom base bot url.
      *
      * @throws TelegramSDKException
      */
-    public function __construct($token = null, $async = false, $httpClientHandler = null)
+    public function __construct($token = null, $async = false, $httpClientHandler = null, $base_bot_url = null)
     {
         $this->accessToken = $token ?? getenv(static::BOT_TOKEN_ENV_NAME);
         $this->validateAccessToken();
@@ -60,6 +61,8 @@ class Api
         }
 
         $this->httpClientHandler = $httpClientHandler;
+
+        $this->baseBotUrl = $base_bot_url;
     }
 
     /**

--- a/src/BotsManager.php
+++ b/src/BotsManager.php
@@ -191,7 +191,8 @@ class BotsManager
         $telegram = new Api(
             $token,
             $this->getConfig('async_requests', false),
-            $this->getConfig('http_client_handler', null)
+            $this->getConfig('http_client_handler', null),
+            $this->getConfig('base_bot_url',null)
         );
 
         // Check if DI needs to be enabled for Commands

--- a/src/Laravel/config/telegram.php
+++ b/src/Laravel/config/telegram.php
@@ -82,6 +82,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Base Bot Url [Optional]
+    |--------------------------------------------------------------------------
+    |
+    | If you'd like to use a custom Base Bot Url.
+    | Should be a local bot api endpoint or a proxy to the telegram api endpoint
+    |
+    | Default: https://api.telegram.org/bot
+    |
+    */
+    'base_bot_url' => null,
+
+    /*
+    |--------------------------------------------------------------------------
     | Resolve Injected Dependencies in commands [Optional]
     |--------------------------------------------------------------------------
     |

--- a/src/TelegramClient.php
+++ b/src/TelegramClient.php
@@ -19,14 +19,20 @@ class TelegramClient
     /** @var HttpClientInterface|null HTTP Client. */
     protected $httpClientHandler;
 
+    /** @var string|null base bot url. */
+    protected $baseBotUrl;
+
     /**
      * Instantiates a new TelegramClient object.
      *
      * @param  HttpClientInterface|null  $httpClientHandler
+     * @param  string|null  $baseBotUrl
      */
-    public function __construct(HttpClientInterface $httpClientHandler = null)
+    public function __construct(HttpClientInterface $httpClientHandler = null, $baseBotUrl = null)
     {
         $this->httpClientHandler = $httpClientHandler ?? new GuzzleHttpClient();
+
+        $this->baseBotUrl = $baseBotUrl;
     }
 
     /**
@@ -111,7 +117,7 @@ class TelegramClient
      */
     public function getBaseBotUrl(): string
     {
-        return static::BASE_BOT_URL;
+        return $this->baseBotUrl ?? static::BASE_BOT_URL;
     }
 
     /**

--- a/src/Traits/Http.php
+++ b/src/Traits/Http.php
@@ -58,6 +58,19 @@ trait Http
     }
 
     /**
+     * Set Http Client Handler.
+     *
+     * @param  string  $baseBotUrl
+     * @return $this
+     */
+    public function setBaseBotUrl(string $baseBotUrl)
+    {
+        $this->baseBotUrl = $baseBotUrl;
+
+        return $this;
+    }
+
+    /**
      * Returns the TelegramClient service.
      *
      * @return TelegramClient

--- a/src/Traits/Http.php
+++ b/src/Traits/Http.php
@@ -29,6 +29,9 @@ trait Http
     /** @var HttpClientInterface|null Http Client Handler */
     protected $httpClientHandler = null;
 
+    /** @var string|null Base Bot Url */
+    protected $baseBotUrl = null;
+
     /** @var bool Indicates if the request to Telegram will be asynchronous (non-blocking). */
     protected $isAsyncRequest = false;
 
@@ -62,7 +65,7 @@ trait Http
     protected function getClient(): TelegramClient
     {
         if ($this->client === null) {
-            $this->client = new TelegramClient($this->httpClientHandler);
+            $this->client = new TelegramClient($this->httpClientHandler, $this->baseBotUrl);
         }
 
         return $this->client;


### PR DESCRIPTION
this PR will close the https://github.com/irazasyed/telegram-bot-sdk/issues/941 and https://github.com/irazasyed/telegram-bot-sdk/issues/942 
as you know telegram offers a local bot API server and in some cases like censorship we can use a proxy to send our requests to telegram for example using this repo https://github.com/manzoorwanijk/telegram-bot-api-worker we can create a Cloudflare worker to send requests to the telegram sever in restricted internet and all these situations need custom BASE_BOT_URL.

I've added a fourth parameter to the API Class that accepts BASE_BOT_URL and for laravel users, I've added a config option called `base_bot_url` so that users can set their custom bot base URL.
function `setBaseBotUrl(string $baseBotUrl)` was also added to the API class.