### PR TITLE
Solve Deprecation error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,8 @@
   },
   "require-dev": {
     "php-parallel-lint/php-parallel-lint": "^1.3",
+    "phpspec/prophecy": "^1.16",
+    "phpspec/prophecy-phpunit": "^2.0",
     "phpunit/phpunit": "^9.5"
   },
   "autoload": {

--- a/tests/Integration/TelegramApiTest.php
+++ b/tests/Integration/TelegramApiTest.php
@@ -9,6 +9,7 @@ use League\Event\Emitter;
 use League\Event\EventInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Telegram\Bot\Api;
 use Telegram\Bot\Commands\CommandBus;
 use Telegram\Bot\Events\UpdateEvent;
@@ -28,6 +29,7 @@ class TelegramApiTest extends TestCase
 {
     use GuzzleMock;
     use CommandGenerator;
+    use ProphecyTrait;
 
     protected function tearDown(): void
     {

--- a/tests/Unit/Commands/CommandBusTest.php
+++ b/tests/Unit/Commands/CommandBusTest.php
@@ -4,6 +4,7 @@ namespace Telegram\Bot\Tests\Unit\Commands;
 
 use Illuminate\Support\Collection;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Telegram\Bot\Commands\Command;
 use Telegram\Bot\Commands\CommandBus;
 use Telegram\Bot\Exceptions\TelegramSDKException;
@@ -11,8 +12,7 @@ use Telegram\Bot\Tests\Traits\CommandGenerator;
 
 class CommandBusTest extends TestCase
 {
-    use CommandGenerator;
-
+    use CommandGenerator, ProphecyTrait;
     /**
      * @var CommandBus
      */

--- a/tests/Unit/Commands/CommandTest.php
+++ b/tests/Unit/Commands/CommandTest.php
@@ -3,12 +3,15 @@
 namespace Telegram\Bot\Tests\Unit\Commands;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Telegram\Bot\Api;
 use Telegram\Bot\Commands\Command;
 use Telegram\Bot\Objects\Update;
 
 class CommandTest extends TestCase
 {
+    use ProphecyTrait;
+
     protected $api;
 
     /**

--- a/tests/Unit/Commands/HelpCommandTest.php
+++ b/tests/Unit/Commands/HelpCommandTest.php
@@ -4,6 +4,7 @@ namespace Telegram\Bot\Tests\Unit\Commands;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Telegram\Bot\Api;
 use Telegram\Bot\Commands\HelpCommand;
 use Telegram\Bot\Objects\Message;
@@ -11,6 +12,8 @@ use Telegram\Bot\Objects\Update;
 
 class HelpCommandTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @test it makes the make method work */
     public function it_ensures_a_command_make_method_works()
     {


### PR DESCRIPTION
Because PHPUnit\Framework\TestCase::prophesize() is deprecated and will be removed in PHPUnit 10 then we can use phpspec/prophecy-phpunit package