### PR TITLE
Fix WebhookCommand --info parameter.

### DIFF
--- a/src/Laravel/Artisan/WebhookCommand.php
+++ b/src/Laravel/Artisan/WebhookCommand.php
@@ -130,7 +130,8 @@ class WebhookCommand extends Command
 
         if ($this->hasArgument('bot') && ! $this->option('all')) {
             $response = $this->telegram->getWebhookInfo();
-            $this->makeWebhookInfoResponse($response, $this->argument('bot'));
+            $bot = $this->botsManager->getBotConfig($this->argument('bot'))['bot'];
+            $this->makeWebhookInfoResponse($response, $bot);
 
             return;
         }


### PR DESCRIPTION
When running the command:
`php artisan telegram:webhook --info`

we can see the error: `Telegram\Bot\Laravel\Artisan\WebhookCommand::makeWebhookInfoResponse(): Argument #2 ($bot) must be of type string, null given, called in...`