### PR TITLE
Fix showing the webhook information in an Artisan command

### DIFF
--- a/src/Laravel/Artisan/WebhookCommand.php
+++ b/src/Laravel/Artisan/WebhookCommand.php
@@ -149,7 +149,7 @@ class WebhookCommand extends Command
     {
         $rows = $response->map(function ($value, $key): array {
             $key = Str::title(str_replace('_', ' ', $key));
-            $value = is_bool($value) ? $this->mapBool($value) : $value;
+            $value = is_bool($value) ? $this->mapBool($value) : (is_array($value) ? implode("\n", $value) : $value);
 
             return ['key' => $key, 'value' => $value];
         })->toArray();


### PR DESCRIPTION
Getting a WebHook info using the artisan command `php artisan telegram:webhook bot_name --info` throws an exception now:
```
A cell must be a TableCell, a scalar or an object implementing "__toString()", "array" given. 
```

That's because of the `WebhookInfo` containing the `allowed_updates` field of the type `array of string`. Here is a link to the documentation: https://core.telegram.org/bots/api#webhookinfo.

The proposed change converts the received array to a string, so it could be easily represented in a console window:
```
************************
*     Webhook Info     *
************************

+------------------------+----------------------+
| Bot: bot_name                                 |
+------------------------+----------------------+
| Key                    | Info                 |
+------------------------+----------------------+
| Url                    |                      |
| Has Custom Certificate | No                   |
| Pending Update Count   | 0                    |
| Allowed Updates        | message              |
|                        | edited_message       |
|                        | channel_post         |
|                        | edited_channel_post  |
|                        | inline_query         |
|                        | chosen_inline_result |
|                        | callback_query       |
|                        | shipping_query       |
|                        | pre_checkout_query   |
|                        | poll                 |
|                        | poll_answer          |
|                        | my_chat_member       |
|                        | chat_member          |
|                        | chat_join_request    |
+------------------------+----------------------+
```