### PR TITLE
Update TelegramRequest.php

### DIFF
--- a/src/TelegramRequest.php
+++ b/src/TelegramRequest.php
@@ -15,10 +15,10 @@ final class TelegramRequest
     private ?string $accessToken;
 
     /** @var string The HTTP method for this request. */
-    private string $method;
+    private ?string $method;
 
     /** @var string The API endpoint for this request. */
-    private string $endpoint;
+    private ?string $endpoint;
 
     /** @var array The headers to send with this request. */
     private array $headers = [];
@@ -87,7 +87,7 @@ final class TelegramRequest
     /**
      * Set the bot access token for this request.
      */
-    public function setAccessToken(string $accessToken): self
+    public function setAccessToken(string|null $accessToken): self
     {
         $this->accessToken = $accessToken;
 
@@ -121,7 +121,7 @@ final class TelegramRequest
     /**
      * Set the endpoint for this request.
      */
-    public function setEndpoint(string $endpoint): self
+    public function setEndpoint(string|null $endpoint): self
     {
         $this->endpoint = $endpoint;
 
@@ -189,7 +189,7 @@ final class TelegramRequest
     /**
      * Set the HTTP method for this request.
      */
-    public function setMethod(string $method): self
+    public function setMethod(string|null $method): self
     {
         $this->method = strtoupper($method);
 


### PR DESCRIPTION
in construct when properties could be null, type of these setter methods value should be also include type of null. in other case these errors will throw :
Argument #1 ($accessToken) must be of type string, null given
Argument #1 ($endpoint) must be of type string, null given
Argument #1 ($method) must be of type string, null given