### PR TITLE
Update Command.php

### DIFF
--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -195,7 +195,7 @@ abstract class Command implements CommandInterface
         return [$pattern, $patterns->keys()->all()];
     }
 
-    private function relevantMessageSubString(): bool|string
+    private function relevantMessageSubString(): bool|string|null
     {
         //Get all the bot_command offsets in the Update object
         $commandOffsets = $this->allCommandOffsets();


### PR DESCRIPTION
when i'm sending an image from bot, and i'm gonna trigger a command by using this :
`Telegram::triggerCommand()`
this error will throw :
Telegram\Bot\Commands\Command::relevantMessageSubString(): Return value must be of type string|bool, null returned

it because of the method type of relevantMessageSubString
by adding the type of null to this method, it will fix.