### PR TITLE
Add a setup method for the "is_persistent" field of the ReplyKeyboardMarkup object

### DIFF
--- a/src/Keyboard/Keyboard.php
+++ b/src/Keyboard/Keyboard.php
@@ -11,6 +11,7 @@ use Telegram\Bot\Objects\LoginUrl;
  * // For Standard Keyboard
  * $params = [
  *   'keyboard'          => '',
+ *   'is_persistent'     => '',
  *   'resize_keyboard'   => '',
  *   'one_time_keyboard' => '',
  *   'selective'         => '',
@@ -26,6 +27,7 @@ use Telegram\Bot\Objects\LoginUrl;
  * ];
  * </code>
  *
+ * @method $this setIsPersistent($boolean)       Optional. Requests clients to always show the keyboard when the regular keyboard is hidden.
  * @method $this setResizeKeyboard($boolean)     Optional. Requests clients to resize the keyboard vertically for optimal fit.
  * @method $this setOneTimeKeyboard($boolean)    Optional. Requests clients to hide the keyboard as soon as it's been used.
  * @method $this setSelective($boolean)          Optional. Use this parameter if you want to show the keyboard to specific users only.


### PR DESCRIPTION
This PR just "adds" a convenient method for setting the [is_persistent](https://core.telegram.org/bots/api#replykeyboardmarkup) field which was [introduced](https://core.telegram.org/bots/api#december-30-2022) in the Bot API 6.4:

> Added the field is_persistent to the class [ReplyKeyboardMarkup](https://core.telegram.org/bots/api#replykeyboardmarkup), allowing to control when the keyboard is shown.

**P.S.** One could already use the `setIsPersistent()` method, but with this change, it will be shown by the autocomplete system of an IDE.