### PR TITLE
Allow to add commands stored in an iterable

### DIFF
--- a/src/Commands/CommandBus.php
+++ b/src/Commands/CommandBus.php
@@ -49,11 +49,11 @@ class CommandBus extends AnswerBus
     /**
      * Add a list of commands.
      *
-     * @param  list<CommandInterface|class-string<CommandInterface>>  $commands
+     * @param iterable<CommandInterface|class-string<CommandInterface>>  $commands
      *
      * @throws TelegramSDKException
      */
-    public function addCommands(array $commands): self
+    public function addCommands(iterable $commands): self
     {
         foreach ($commands as $command) {
             $this->addCommand($command);

--- a/tests/Unit/Commands/CommandBus.php
+++ b/tests/Unit/Commands/CommandBus.php
@@ -34,6 +34,15 @@ it('can add multiple commands to the bus', function () {
     expect($result)->toHaveCount(4);
 });
 
+it('can add multiple commands contained in an iterator to the bus', function () {
+    $iterator = new ArrayIterator($this->commandGenerator(4)->all());
+
+    $this->bus->addCommands($iterator);
+    $result = $this->bus->getCommands();
+
+    expect($result)->toHaveCount(4);
+});
+
 it('throws an exception if a no class exists for the name supplied as a command')
     ->tap(fn () => $this->bus->addCommand('badcommand'))
     ->throws(TelegramSDKException::class);


### PR DESCRIPTION
Adding several commands with a single method call can be really useful, especially when working with a framework that can detect all commands instances and inject them in the command bus automatically.

This commit allows commands registration using an iterable, enhancing the possibilities to — for instance — lazy-load the commands only when the SDK API is actually called.

Below is an example of how the `Api` class is declared in a recent Symfony application:

```php
return static function (ContainerConfigurator $container): void {
    $container
        ->services()

        // Tagging all commands, so they can be retrieved below
        ->instanceof(\Telegram\Bot\Commands\CommandInterface::class)
        ->tag('telegram.command')

        // Registering the `Api` class
        ->set(Api::class)
        ->args([
            '$token' => env('TELEGRAM_BOT_TOKEN')->resolve(),
        ])
        // Adding all commands that were previously tagged
        ->call('addCommands', [tagged_iterator('telegram.command')]);
};
```

The example above would not work without changing the type of the parameter, because the `tagged_iterator` is not an array.