### PR TITLE
Fixed: Class `Telegram\Bot\Methods\Arr` not found

### DIFF
--- a/src/Methods/Message.php
+++ b/src/Methods/Message.php
@@ -2,6 +2,7 @@
 
 namespace Telegram\Bot\Methods;
 
+use Illuminate\Support\Arr;
 use Telegram\Bot\Actions;
 use Telegram\Bot\Exceptions\TelegramSDKException;
 use Telegram\Bot\Objects\Message as MessageObject;


### PR DESCRIPTION
When trying to send a reaction to a message, this problem occurred.

```php
$bot->api()->setMessageReaction([
    'chat_id' => $chatId,
    'message_id' => $messageId,
    'reaction' => [
       [
           'type' => 'emoji',
           'emoji' => '👍',
       ],
    ],
]);
```