### PR TITLE
Update Http.php

### DIFF
--- a/src/Traits/Http.php
+++ b/src/Traits/Http.php
@@ -262,7 +262,7 @@ trait Http
      *
      * @throws TelegramSDKException
      */
-    protected function post(string $endpoint, array $params = [], bool $fileUpload = false): TelegramResponse
+    public function post(string $endpoint, array $params = [], bool $fileUpload = false): TelegramResponse
     {
         $params = $this->normalizeParams($params, $fileUpload);
 


### PR DESCRIPTION
Since the library isn't keeping up with new methods, I change the visibility of this method to public hence we could use something like:

for example we do not have `createInvoiceLink` right now:

```php
$telegram->post('createInvoiceLink', $params);
```