### PR TITLE
Add support for dynamic bot tokens

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -75,7 +75,7 @@ class Api
     public function __construct(?string $token = null, bool $async = false, ?HttpClientInterface $httpClientHandler = null, ?string $baseBotUrl = null)
     {
         $this->setAccessToken($token ?? getenv(self::BOT_TOKEN_ENV_NAME));
-        $this->validateAccessToken();
+        $this->validateAccessToken($token);
 
         if ($async) {
             $this->setAsyncRequest($async);
@@ -90,9 +90,9 @@ class Api
     /**
      * @throws TelegramSDKException
      */
-    private function validateAccessToken(): void
+    private function validateAccessToken(?string $token = null): void
     {
-        if ($this->getAccessToken() === '' || $this->getAccessToken() === '0') {
+        if (($token === null || $token === '') && ($this->getAccessToken() === '' || $this->getAccessToken() === '0')) {
             throw TelegramSDKException::tokenNotProvided(self::BOT_TOKEN_ENV_NAME);
         }
     }
@@ -127,5 +127,15 @@ class Api
         }
 
         throw new BadMethodCallException(sprintf('Method [%s] does not exist.', $method));
+    }
+
+    /**
+     * Set the bot access token dynamically.
+     */
+    public function setAccessToken(string $accessToken): self
+    {
+        $this->accessToken = $accessToken;
+
+        return $this;
     }
 }

--- a/src/BotsManager.php
+++ b/src/BotsManager.php
@@ -64,12 +64,12 @@ final class BotsManager
      *
      * @throws TelegramSDKException
      */
-    public function bot(?string $name = null): Api
+    public function bot(?string $name = null, ?string $token = null): Api
     {
         $name ??= $this->getDefaultBotName();
 
         if (! isset($this->bots[$name])) {
-            $this->bots[$name] = $this->makeBot($name);
+            $this->bots[$name] = $this->makeBot($name, $token);
         }
 
         return $this->bots[$name];
@@ -150,11 +150,11 @@ final class BotsManager
      *
      * @throws TelegramSDKException
      */
-    protected function makeBot(string $name): Api
+    protected function makeBot(string $name, ?string $token = null): Api
     {
         $config = $this->getBotConfig($name);
 
-        $token = data_get($config, 'token');
+        $token = $token ?? data_get($config, 'token');
 
         $telegram = new Api(
             $token,
@@ -175,6 +175,16 @@ final class BotsManager
         $telegram->addCommands($commands);
 
         return $telegram;
+    }
+
+    /**
+     * Create a new bot instance with a dynamic token.
+     *
+     * @throws TelegramSDKException
+     */
+    public function createBotInstance(string $name, string $token): Api
+    {
+        return $this->makeBot($name, $token);
     }
 
     /**

--- a/src/Laravel/TelegramServiceProvider.php
+++ b/src/Laravel/TelegramServiceProvider.php
@@ -56,7 +56,7 @@ final class TelegramServiceProvider extends ServiceProvider implements Deferrabl
         $this->app->singleton(BotsManager::class, static fn ($app): BotsManager => (new BotsManager(config('telegram')))->setContainer($app));
         $this->app->alias(BotsManager::class, 'telegram');
 
-        $this->app->bind(Api::class, static fn ($app) => $app[BotsManager::class]->bot());
+        $this->app->bind(Api::class, static fn ($app, $params) => $app[BotsManager::class]->bot($params['token'] ?? null));
         $this->app->alias(Api::class, 'telegram.bot');
     }
 

--- a/src/Laravel/config/telegram.php
+++ b/src/Laravel/config/telegram.php
@@ -32,7 +32,7 @@ return [
     */
     'bots' => [
         'mybot' => [
-            'token' => env('TELEGRAM_BOT_TOKEN', 'YOUR-BOT-TOKEN'),
+            'token' => null,
             'certificate_path' => env('TELEGRAM_CERTIFICATE_PATH', 'YOUR-CERTIFICATE-PATH'),
             'webhook_url' => env('TELEGRAM_WEBHOOK_URL', 'YOUR-BOT-WEBHOOK-URL'),
             /*
@@ -45,7 +45,7 @@ return [
         ],
 
         //        'mySecondBot' => [
-        //            'token' => '123456:abc',
+        //            'token' => null,
         //        ],
     ],
 


### PR DESCRIPTION
Add support for creating multiple bot instances at runtime with various tokens passed in post messages instead of the `.env`.

* **src/Api.php**
  - Add `setAccessToken` method to set the token dynamically.
  - Modify the constructor to accept a token parameter.
  - Update `validateAccessToken` method to check for the token parameter.

* **src/BotsManager.php**
  - Add `createBotInstance` method to create a bot instance with a dynamic token.
  - Modify the `bot` method to accept a token parameter.
  - Update the `makeBot` method to use the token parameter.

* **src/Laravel/TelegramServiceProvider.php**
  - Modify the `registerBindings` method to register bot instances with dynamic tokens.
  - Update the `register` method to accept a token parameter.

* **src/Laravel/config/telegram.php**
  - Remove reliance on environment variables for bot tokens.
  - Update the `bots` array to accept dynamic tokens.

