### PR TITLE
Add rich message support

### DIFF
--- a/src/Laravel/Facades/Telegram.php
+++ b/src/Laravel/Facades/Telegram.php
@@ -102,6 +102,8 @@ use Telegram\Bot\BotsManager;
  * @method static void flushMacros()
  * @method static void macroCall($method, $parameters)
  * @method static \Telegram\Bot\Objects\Message sendMessage(array $params)
+ * @method static \Telegram\Bot\Objects\Message sendRichMessage(array $params)
+ * @method static bool sendRichMessageDraft(array $params)
  * @method static \Telegram\Bot\Objects\Message forwardMessage(array $params)
  * @method static \Telegram\Bot\Objects\Message copyMessage(array $params)
  * @method static \Telegram\Bot\Objects\Message sendPhoto(array $params)

--- a/src/Methods/EditMessage.php
+++ b/src/Methods/EditMessage.php
@@ -22,10 +22,11 @@ trait EditMessage
      *       'chat_id'                   => '',  // int|string - (Optional). Required if inline_message_id is not specified. Unique identifier for the target chat or username of the target channel (in the format "@channelusername")
      *       'message_id'                => '',  // int        - (Optional). Required if inline_message_id is not specified. Identifier of the sent message
      *       'inline_message_id'         => '',  // string     - (Optional). Required if chat_id and message_id are not specified. Identifier of the inline message
-     *       'text'                      => '',  // string     - Required. New text of the message.
+     *       'text'                      => '',  // string     - (Optional). New text of the message. Required if rich_message is not specified.
      *       'parse_mode'                => '',  // string     - (Optional). Send Markdown or HTML, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.
      *       'entities'                  => '',  // array      - (Optional). List of special entities that appear in the caption, which can be specified instead of parse_mode
      *       'disable_web_page_preview'  => '',  // bool       - (Optional). Disables link previews for links in this message
+     *       'rich_message'              => '',  // InputRichMessage|string - (Optional). New rich content. Required if text is not specified.
      *       'reply_markup'              => '',  // string     - (Optional). A JSON-serialized object for an inline keyboard.
      * ]
      * </code>
@@ -38,6 +39,7 @@ trait EditMessage
      */
     public function editMessageText(array $params): Message
     {
+        $params = $this->inputRichMessageToString($params);
         $response = $this->post('editMessageText', $params);
 
         return new Message($response->getDecodedBody());

--- a/src/Methods/Message.php
+++ b/src/Methods/Message.php
@@ -45,6 +45,42 @@ trait Message
     }
 
     /**
+     * Send a rich formatted message.
+     *
+     * The rich_message parameter accepts an InputRichMessage containing markdown or HTML,
+     * or an already JSON-serialized string.
+     *
+     * @link https://core.telegram.org/bots/api#sendrichmessage
+     *
+     * @throws TelegramSDKException
+     */
+    public function sendRichMessage(array $params): MessageObject
+    {
+        $params = $this->inputRichMessageToString($params);
+        $response = $this->post('sendRichMessage', $params);
+
+        return new MessageObject($response->getDecodedBody());
+    }
+
+    /**
+     * Stream a partial rich message while it is being generated.
+     *
+     * The rich_message parameter accepts an InputRichMessage containing markdown or HTML,
+     * or an already JSON-serialized string. The draft is an ephemeral 30-second preview; call
+     * sendRichMessage with the complete message to persist it.
+     *
+     * @link https://core.telegram.org/bots/api#sendrichmessagedraft
+     *
+     * @throws TelegramSDKException
+     */
+    public function sendRichMessageDraft(array $params): bool
+    {
+        $params = $this->inputRichMessageToString($params);
+
+        return $this->post('sendRichMessageDraft', $params)->getResult();
+    }
+
+    /**
      * Forward messages of any kind.
      *
      * <code>

--- a/src/Objects/InputRichMessage.php
+++ b/src/Objects/InputRichMessage.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Telegram\Bot\Objects;
+
+/**
+ * A rich message to be sent using Markdown or HTML formatting.
+ *
+ * Exactly one of html or markdown must be specified.
+ *
+ * @link https://core.telegram.org/bots/api#inputrichmessage
+ *
+ * @property string|null $html (Optional). Rich message content using HTML formatting.
+ * @property string|null $markdown (Optional). Rich message content using Markdown formatting.
+ * @property bool|null $isRtl (Optional). True, if the message must be shown right-to-left.
+ * @property bool|null $skipEntityDetection (Optional). True, to skip automatic entity detection.
+ */
+class InputRichMessage extends BaseObject
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function relations(): array
+    {
+        return [];
+    }
+}

--- a/src/Objects/Message.php
+++ b/src/Objects/Message.php
@@ -60,6 +60,7 @@ use Telegram\Bot\Objects\WebApp\WebAppData;
  * @property WebAppData|null $webAppData (Optional). Service message: data sent by a Web App.
  * @property Chat|null $senderChat (Optional). Sender of a message which is a chat (group or channel).
  * @property string|null $sender_tag (Optional). Tag or custom title of the sender of the message; for supergroups only
+ * @property TelegramObject|null $richMessage (Optional). Rich formatted content of the message.
  */
 class Message extends BaseObject
 {
@@ -103,6 +104,7 @@ class Message extends BaseObject
         'voice_chat_participants_invited',
         'web_app_data',
         'sender_tag',
+        'rich_message',
     ];
 
     /**

--- a/src/Traits/Http.php
+++ b/src/Traits/Http.php
@@ -9,6 +9,7 @@ use Telegram\Bot\FileUpload\InputFile;
 use Telegram\Bot\HttpClients\HttpClientInterface;
 use Telegram\Bot\Objects\BaseObject;
 use Telegram\Bot\Objects\File;
+use Telegram\Bot\Objects\InputRichMessage;
 use Telegram\Bot\TelegramClient;
 use Telegram\Bot\TelegramRequest;
 use Telegram\Bot\TelegramResponse;
@@ -126,6 +127,18 @@ trait Http
         $params = $this->replyMarkupToString($params);
 
         return $this->sendRequest('GET', $endpoint, $params);
+    }
+
+    /**
+     * JSON-serialize an InputRichMessage request parameter.
+     */
+    protected function inputRichMessageToString(array $params): array
+    {
+        if (($params['rich_message'] ?? null) instanceof InputRichMessage) {
+            $params['rich_message'] = $params['rich_message']->toJson(JSON_THROW_ON_ERROR);
+        }
+
+        return $params;
     }
 
     /**

--- a/tests/Integration/Api.php
+++ b/tests/Integration/Api.php
@@ -11,7 +11,9 @@ use Telegram\Bot\Exceptions\TelegramResponseException;
 use Telegram\Bot\Exceptions\TelegramSDKException;
 use Telegram\Bot\FileUpload\InputFile;
 use Telegram\Bot\HttpClients\GuzzleHttpClient;
+use Telegram\Bot\Objects\InputRichMessage;
 use Telegram\Bot\Objects\Message;
+use Telegram\Bot\Objects\TelegramObject;
 use Telegram\Bot\Objects\Update;
 use Telegram\Bot\Objects\WebhookInfo;
 use Telegram\Bot\TelegramResponse;
@@ -111,6 +113,66 @@ test('the correct request body data is created when a post method has parameters
         ->and($request->getUri()->getHost())->toEqual('api.telegram.org')
         ->and($request->getUri()->getPath())->toEqual('/botSpecial_Bot_Token/sendMessage')
         ->and($request->getUri()->getQuery())->toEqual('');
+});
+
+test('rich message methods serialize InputRichMessage for the correct endpoints', function () {
+    $markdown = new InputRichMessage([
+        'markdown' => "# Status\n\nAll systems operational.",
+    ]);
+    $draftHtml = new InputRichMessage([
+        'html' => '<tg-thinking>Thinking...</tg-thinking>',
+    ]);
+    $editedHtml = new InputRichMessage([
+        'html' => '<h1>Updated</h1>',
+    ]);
+    $client = $this->getGuzzleHttpClient([
+        $this->makeFakeServerResponse([
+            'message_id' => 42,
+            'date' => 1_700_000_000,
+            'chat' => ['id' => 123, 'type' => 'private'],
+            'rich_message' => [
+                'blocks' => [['type' => 'paragraph', 'text' => 'All systems operational.']],
+            ],
+        ]),
+        $this->makeFakeServerResponse(true),
+        $this->makeFakeServerResponse([
+            'message_id' => 42,
+            'date' => 1_700_000_000,
+            'chat' => ['id' => 123, 'type' => 'private'],
+        ]),
+    ]);
+    $api = api($client, 'Special_Bot_Token');
+
+    $message = $api->sendRichMessage([
+        'chat_id' => 123,
+        'rich_message' => $markdown,
+    ]);
+    $draftSent = $api->sendRichMessageDraft([
+        'chat_id' => 123,
+        'draft_id' => 7,
+        'rich_message' => $draftHtml,
+    ]);
+    $editedMessage = $api->editMessageText([
+        'chat_id' => 123,
+        'message_id' => 42,
+        'rich_message' => $editedHtml,
+    ]);
+
+    $requests = $this->getHistory()->pluck('request')->values();
+    parse_str((string) $requests[0]->getBody(), $sendBody);
+    parse_str((string) $requests[1]->getBody(), $draftBody);
+    parse_str((string) $requests[2]->getBody(), $editBody);
+
+    expect($message)->toBeInstanceOf(Message::class)
+        ->and($message->richMessage)->toBeInstanceOf(TelegramObject::class)
+        ->and($draftSent)->toBeTrue()
+        ->and($editedMessage)->toBeInstanceOf(Message::class)
+        ->and($requests[0]->getUri()->getPath())->toBe('/botSpecial_Bot_Token/sendRichMessage')
+        ->and($sendBody['rich_message'])->toBe($markdown->toJson(JSON_THROW_ON_ERROR))
+        ->and($requests[1]->getUri()->getPath())->toBe('/botSpecial_Bot_Token/sendRichMessageDraft')
+        ->and($draftBody['rich_message'])->toBe($draftHtml->toJson(JSON_THROW_ON_ERROR))
+        ->and($requests[2]->getUri()->getPath())->toBe('/botSpecial_Bot_Token/editMessageText')
+        ->and($editBody['rich_message'])->toBe($editedHtml->toJson(JSON_THROW_ON_ERROR));
 });
 
 it('returns decoded update objects when updates are available', function () {


### PR DESCRIPTION
## Summary

- add sendRichMessage and sendRichMessageDraft API methods
- add InputRichMessage with automatic JSON serialization for Markdown and HTML
- support rich_message in editMessageText and received Message objects
- expose the new methods through the Laravel facade

## Why

Telegram Bot API 10.1 introduced rich messages and streaming rich message drafts. This adds minimal SDK support while leaving message formatting to callers.

## Tests

- vendor/bin/pest: 54 passed, 169 assertions