### PR TITLE
Read local Bot API server file paths directly instead of over HTTP

### DIFF
--- a/src/TelegramClient.php
+++ b/src/TelegramClient.php
@@ -73,7 +73,10 @@ final class TelegramClient
     /**
      * Download file from Telegram server for given file path.
      *
-     * @param  string  $filePath  File path on Telegram server.
+     * @param  string  $filePath  File path on Telegram server. A local Bot API server started
+     *                            with --local returns an absolute path here instead, which is
+     *                            read directly off disk rather than fetched over HTTP, since the
+     *                            local server does not serve files over HTTP in that mode.
      * @param  string  $filename  Download path to save file.
      *
      * @throws TelegramSDKException
@@ -85,6 +88,14 @@ final class TelegramClient
         // Ensure dir is created.
         if (! @mkdir($fileDir, 0755, true) && ! is_dir($fileDir)) {
             throw TelegramSDKException::fileDownloadFailed('Directory '.$fileDir.' can\'t be created');
+        }
+
+        if (str_starts_with($filePath, '/')) {
+            if (! is_readable($filePath) || ! copy($filePath, $filename)) {
+                throw TelegramSDKException::fileDownloadFailed('Could not read local file', $filePath);
+            }
+
+            return $filename;
         }
 
         $response = $this->httpClientHandler

--- a/tests/Integration/Api.php
+++ b/tests/Integration/Api.php
@@ -461,3 +461,73 @@ test('the command handler when using webhook to process updates for commands wil
 
     expect($update)->toBeInstanceOf(Update::class);
 });
+
+test('downloading a file fetches it over http when the file path is relative', function () {
+    $fileContents = 'remote file contents';
+    $response = new \GuzzleHttp\Psr7\Response(200, [], $fileContents);
+    $api = api($this->getGuzzleHttpClient([$response]));
+
+    $destination = sys_get_temp_dir().'/telegram-bot-sdk-test-'.uniqid().'/file.jpg';
+
+    try {
+        $file = new \Telegram\Bot\Objects\File([
+            'file_id' => 'ABC',
+            'file_unique_id' => 'ABC',
+            'file_path' => 'photos/file_0.jpg',
+        ]);
+
+        $api->downloadFile($file, $destination);
+
+        $request = $this->getHistory()->pluck('request')->first();
+
+        expect($this->getHistory())->toHaveCount(1)
+            ->and((string) $request->getUri())->toEqual('https://api.telegram.org/file/botTELEGRAM_TOKEN/photos/file_0.jpg')
+            ->and(file_get_contents($destination))->toEqual($fileContents);
+    } finally {
+        @unlink($destination);
+        @rmdir(dirname($destination));
+    }
+});
+
+test('downloading a file reads it directly from disk when the file path is an absolute local path', function () {
+    // A Bot API server started with --local returns an absolute file_path instead of a
+    // relative one, and does not serve file contents over HTTP in that mode, so the SDK
+    // must read the file directly off disk rather than issuing an HTTP request for it.
+    $api = api($this->getGuzzleHttpClient([]));
+
+    $source = tempnam(sys_get_temp_dir(), 'telegram-bot-sdk-test-source-');
+    file_put_contents($source, 'local file contents');
+    $destination = sys_get_temp_dir().'/telegram-bot-sdk-test-'.uniqid().'/file.jpg';
+
+    try {
+        $file = new \Telegram\Bot\Objects\File([
+            'file_id' => 'ABC',
+            'file_unique_id' => 'ABC',
+            'file_path' => $source,
+        ]);
+
+        $api->downloadFile($file, $destination);
+
+        expect($this->getHistory())->toHaveCount(0)
+            ->and(file_get_contents($destination))->toEqual('local file contents');
+    } finally {
+        @unlink($source);
+        @unlink($destination);
+        @rmdir(dirname($destination));
+    }
+});
+
+test('downloading a file from an absolute local path throws when the file cannot be read', function () {
+    $api = api($this->getGuzzleHttpClient([]));
+
+    $destination = sys_get_temp_dir().'/telegram-bot-sdk-test-'.uniqid().'/file.jpg';
+
+    $file = new \Telegram\Bot\Objects\File([
+        'file_id' => 'ABC',
+        'file_unique_id' => 'ABC',
+        'file_path' => '/nonexistent/directory/file.jpg',
+    ]);
+
+    expect(fn () => $api->downloadFile($file, $destination))
+        ->toThrow(TelegramSDKException::class);
+});


### PR DESCRIPTION
## Summary

When a Bot API server is started with `--local`, `getFile()` returns an absolute local file path instead of a relative one (as documented). `TelegramClient::download()`, however, always builds an HTTP request to `{base}/file/bot{token}/{file_path}` regardless of the path shape.

I traced this against the actual `telegram-bot-api` server source (`HttpConnection::handle()`): the local server's HTTP layer only routes `/bot<token>/<method>` requests — there is no route that serves raw file bytes back over HTTP, in either mode. So for a server running `--local`, every `downloadFile()` call fails with a 404, since the only supported way to retrieve the bytes is to read the absolute path directly off disk (which is exactly what `--local` mode's returned path is for).

This only affects `--local` deployments where the file path is absolute; relative paths (the default, non-local mode) are untouched and keep using the existing HTTP download.

## Changes

- `TelegramClient::download()`: when `$filePath` starts with `/`, read it directly from disk via `copy()` instead of issuing an HTTP request.
- Added tests covering: relative-path downloads still go over HTTP, absolute-path downloads read from disk with no HTTP request made, and a missing/unreadable local file throws `TelegramSDKException`.

## Test plan

- [x] `composer test:unit` — all 3 new tests pass; pre-existing failures (`Command.php`'s `getMockForAbstractClass`, `test:refactor` Rector diffs) reproduce identically on a clean `master` checkout and are unrelated to this change.
- [x] `composer test:lint` — passes.