### PR TITLE
Make Laravel config serializable

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -4,6 +4,8 @@ namespace Telegram\Bot;
 
 use BadMethodCallException;
 use Illuminate\Support\Traits\Macroable;
+use ReflectionClass;
+use ReflectionException;
 use Telegram\Bot\Commands\CommandBus;
 use Telegram\Bot\Events\HasEventDispatcher;
 use Telegram\Bot\Exceptions\TelegramSDKException;
@@ -67,12 +69,12 @@ class Api
      *
      * @param  string|null  $token  The Telegram Bot API Access Token.
      * @param  bool  $async  (Optional) Indicates if the request to Telegram will be asynchronous (non-blocking).
-     * @param  HttpClientInterface|null  $httpClientHandler  (Optional) Custom HTTP Client Handler.
+     * @param  HttpClientInterface|class-string<HttpClientInterface>|null  $httpClientHandler  (Optional) Custom HTTP Client Handler.
      * @param  string|null  $baseBotUrl  (Optional) Custom base bot url.
      *
      * @throws TelegramSDKException
      */
-    public function __construct(?string $token = null, bool $async = false, ?HttpClientInterface $httpClientHandler = null, ?string $baseBotUrl = null)
+    public function __construct(?string $token = null, bool $async = false, string|HttpClientInterface|null $httpClientHandler = null, ?string $baseBotUrl = null)
     {
         $this->setAccessToken($token ?? getenv(self::BOT_TOKEN_ENV_NAME));
         $this->validateAccessToken();
@@ -81,7 +83,7 @@ class Api
             $this->setAsyncRequest($async);
         }
 
-        $this->httpClientHandler = $httpClientHandler;
+        $this->httpClientHandler = $this->resolveHttpClientHandler($httpClientHandler);
 
         $this->baseBotUrl = $baseBotUrl;
         $this->commandBus = new CommandBus($this);
@@ -127,5 +129,34 @@ class Api
         }
 
         throw new BadMethodCallException(sprintf('Method [%s] does not exist.', $method));
+    }
+
+    /**
+     * Resolve an HTTP client handler instance.
+     *
+     * @param  HttpClientInterface|class-string<HttpClientInterface>|null  $httpClientHandler
+     *
+     * @throws TelegramSDKException|ReflectionException
+     */
+    private function resolveHttpClientHandler(HttpClientInterface|string|null $httpClientHandler): ?HttpClientInterface
+    {
+        if (! is_string($httpClientHandler)) {
+            return $httpClientHandler;
+        }
+
+        // Check the class implements the interface
+        if (! is_a($httpClientHandler, HttpClientInterface::class, true)) {
+            throw new TelegramSDKException('The httpClientHandler parameter must be a valid class-string implementing HttpClientInterface.');
+        }
+
+        $reflection = new ReflectionClass($httpClientHandler);
+        $constructor = $reflection->getConstructor();
+
+        // Check it can be instantiated safely
+        if (! $reflection->isInstantiable() || ($constructor !== null && $constructor->getNumberOfRequiredParameters() > 0)) {
+            throw new TelegramSDKException('The httpClientHandler class must be instantiable without constructor arguments.');
+        }
+
+        return new $httpClientHandler;
     }
 }

--- a/src/Laravel/config/telegram.php
+++ b/src/Laravel/config/telegram.php
@@ -79,7 +79,8 @@ return [
     |--------------------------------------------------------------------------
     |
     | If you'd like to use a custom HTTP Client Handler.
-    | Should be an instance of \Telegram\Bot\HttpClients\HttpClientInterface
+    | Can be an instance or a class-string implementing \Telegram\Bot\HttpClients\HttpClientInterface.
+    | Using a class-string ensures the configuration can be cached.
     |
     | Default: GuzzlePHP
     |

--- a/tests/Integration/Api.php
+++ b/tests/Integration/Api.php
@@ -11,6 +11,7 @@ use Telegram\Bot\Exceptions\TelegramResponseException;
 use Telegram\Bot\Exceptions\TelegramSDKException;
 use Telegram\Bot\FileUpload\InputFile;
 use Telegram\Bot\HttpClients\GuzzleHttpClient;
+use Telegram\Bot\HttpClients\HttpClientInterface;
 use Telegram\Bot\Objects\InputRichMessage;
 use Telegram\Bot\Objects\Message;
 use Telegram\Bot\Objects\TelegramObject;
@@ -44,6 +45,32 @@ it('uses the default Guzzle http client if none is specified', function () {
 
     expect($httpClientHandler)->toBeInstanceOf(GuzzleHttpClient::class);
 });
+
+it('resolves the http client handler from a class string', function () {
+    $httpClient = api(GuzzleHttpClient::class)->getClient()->getHttpClientHandler();
+
+    expect($httpClient)->toBeInstanceOf(GuzzleHttpClient::class);
+});
+
+it('throws an exception when the http client handler class string is invalid', function () {
+    api(stdClass::class);
+})->throws(TelegramSDKException::class, 'The httpClientHandler parameter must be a valid class-string implementing HttpClientInterface.');
+
+it('throws an exception when the http client handler cannot be instantiated', function () {
+    api(HttpClientInterface::class);
+})->throws(TelegramSDKException::class, 'The httpClientHandler class must be instantiable without constructor arguments.');
+
+it('throws an exception when the http client handler requires constructor arguments', function () {
+    $httpClientHandler = new class('required argument') extends GuzzleHttpClient
+    {
+        public function __construct(string $requiredArgument)
+        {
+            parent::__construct();
+        }
+    };
+
+    api($httpClientHandler::class);
+})->throws(TelegramSDKException::class, 'The httpClientHandler class must be instantiable without constructor arguments.');
 
 it('uses a Guzzle client with a mock queue without error', function () {
     expect($this->api)->toBeInstanceOf(Api::class);

--- a/tests/Integration/BotsManager.php
+++ b/tests/Integration/BotsManager.php
@@ -2,6 +2,7 @@
 
 use Telegram\Bot\BotsManager;
 use Telegram\Bot\Exceptions\TelegramBotNotFoundException;
+use Telegram\Bot\HttpClients\GuzzleHttpClient;
 
 beforeEach(function () {
     $this->manager = new BotsManager(botsManager());
@@ -22,6 +23,18 @@ test('an invalid or missing config parameter returns null')
     ->toBeInstanceOf(BotsManager::class)
     ->getDefaultBotName()
     ->toBeNull();
+
+it('resolves an http client handler class string from config', function () {
+    $config = botsManager();
+    $config['http_client_handler'] = GuzzleHttpClient::class;
+
+    $httpClientHandler = (new BotsManager($config))
+        ->bot()
+        ->getClient()
+        ->getHttpClientHandler();
+
+    expect($httpClientHandler)->toBeInstanceOf(GuzzleHttpClient::class);
+});
 
 it('is possible to remove a bot from the manager but leave the others', function () {
     $this->manager->bot('bot1');


### PR DESCRIPTION
This change allows the config variable `http_client_handler` to contain a class-string so the Laravel config can be serialized (and cached) via `php artisan config:cache`. Resolves #1174